### PR TITLE
Added SPI mock with transaction based expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ to hardware.
 ## Status
 
 - [x] Simple I2C implementation
+- [x] Transactional SPI implementation
 - [x] No-op Delay implementation
 
 ## no\_std
@@ -40,6 +41,32 @@ let buf = [1, 2, 4];
 i2c.write(42, &buf).unwrap();
 assert_eq!(i2c.get_last_address(), Some(42));
 assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
+```
+
+### SPI
+
+```rust
+use hal::blocking::spi::{Transfer, Write};
+use embedded_hal_mock::SPIMock;
+
+let mut spi = SPIMock::new();
+
+// Configure expectations
+spi.expect(vec![
+    Transaction::write(vec![1u8, 2u8]),
+    Transaction::transfer(vec![3u8, 4u8], vec![5u8, 6u8]),
+]);
+
+// Writing
+spi.write(&vec![1u8, 2u8]).unwrap();
+
+// Transferring
+let mut v = vec![3u8, 4u8];
+spi.transfer(&mut v).unwrap();
+assert_eq!(v, vec![5u8, 6u8]);
+
+// Finalise expectations
+spi.done();
 ```
 
 ### Delay

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
 
 ```rust
 use hal::blocking::spi::{Transfer, Write};
-use embedded_hal_mock::{SPIMock, SPITransaction};
+use embedded_hal_mock::{SpiMock, SpiTransaction};
 
-let mut spi = SPIMock::new();
+let mut spi = SpiMock::new();
 
 // Configure expectations
 spi.expect(vec![
-    SPITransaction::write(vec![1u8, 2u8]),
-    SPITransaction::transfer(vec![3u8, 4u8], vec![5u8, 6u8]),
+    SpiTransaction::write(vec![1u8, 2u8]),
+    SpiTransaction::transfer(vec![3u8, 4u8], vec![5u8, 6u8]),
 ]);
 
 // Writing

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
 
 ```rust
 use hal::blocking::spi::{Transfer, Write};
-use embedded_hal_mock::SPIMock;
+use embedded_hal_mock::{SPIMock, SPITransaction};
 
 let mut spi = SPIMock::new();
 
 // Configure expectations
 spi.expect(vec![
-    Transaction::write(vec![1u8, 2u8]),
-    Transaction::transfer(vec![3u8, 4u8], vec![5u8, 6u8]),
+    SPITransaction::write(vec![1u8, 2u8]),
+    SPITransaction::transfer(vec![3u8, 4u8], vec![5u8, 6u8]),
 ]);
 
 // Writing

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ spi.expect(vec![
 spi.write(&vec![1u8, 2u8]).unwrap();
 
 // Transferring
-let mut v = vec![3u8, 4u8];
-spi.transfer(&mut v).unwrap();
-assert_eq!(v, vec![5u8, 6u8]);
+let mut buf = vec![3u8, 4u8];
+spi.transfer(&mut buf).unwrap();
+assert_eq!(buf, vec![5u8, 6u8]);
 
 // Finalise expectations
 spi.done();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-
 use std::io;
 
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,13 @@
+
+use std::io;
+
+#[derive(Debug)]
+pub enum MockError {
+    Io(io::Error),
+}
+
+impl From<io::Error> for MockError {
+    fn from(e: io::Error) -> Self {
+        MockError::Io(e)
+    }
+}

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,154 @@
+
+
+use std::io::{self, Read};
+
+use hal::blocking::i2c;
+
+use ::error::MockError;
+
+
+const WRITE_BUF_SIZE: usize = 64;
+
+pub struct I2cMock<'a> {
+    data: &'a [u8],
+    address: Option<u8>,
+    buf: [u8; WRITE_BUF_SIZE],
+    buf_bytes_written: usize,
+}
+
+impl<'a> I2cMock<'a> {
+    pub fn new() -> Self {
+        I2cMock {
+            data: &[],
+            address: None,
+            buf: [0; WRITE_BUF_SIZE],
+            buf_bytes_written: 0,
+        }
+    }
+
+    /// Set data that will be read by `read()`.
+    pub fn set_read_data(&mut self, data: &'a [u8]) {
+        self.data = data;
+    }
+
+    /// Return the data that was written by the last write command.
+    pub fn get_write_data(&self) -> &[u8] {
+        &self.buf[0..self.buf_bytes_written]
+    }
+
+    /// Return the address that was used by the last read or write command.
+    pub fn get_last_address(&self) -> Option<u8> {
+        self.address
+    }
+}
+
+impl<'a> i2c::Read for I2cMock<'a> {
+    type Error = MockError;
+
+    fn read(&mut self, address: u8, mut buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.address = Some(address);
+        self.data.read(&mut buffer)?;
+        Ok(())
+    }
+}
+
+impl<'a> i2c::Write for I2cMock<'a> {
+    type Error = MockError;
+
+    fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        if bytes.len() > WRITE_BUF_SIZE {
+            panic!("Write buffer is too small for this number of bytes ({} > {})",
+                   bytes.len(), WRITE_BUF_SIZE);
+        }
+        self.address = Some(address);
+        self.buf[0..bytes.len()].copy_from_slice(bytes);
+        self.buf_bytes_written = bytes.len();
+        Ok(())
+    }
+}
+
+impl<'a> i2c::WriteRead for I2cMock<'a> {
+    type Error = MockError;
+
+    fn write_read(
+        &mut self,
+        address: u8,
+        bytes: &[u8],
+        mut buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        if bytes.len() > WRITE_BUF_SIZE {
+            panic!("Write buffer is too small for this number of bytes ({} > {})",
+                   bytes.len(), WRITE_BUF_SIZE);
+        }
+        self.address = Some(address);
+        self.data.read(&mut buffer)?;
+        self.buf[0..bytes.len()].copy_from_slice(bytes);
+        self.buf_bytes_written = bytes.len();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use hal::blocking::i2c::{Read, Write, WriteRead};
+
+    #[test]
+    fn i2c_read_no_data_set() {
+        let mut i2c = I2cMock::new();
+        let mut buf = [0; 3];
+        i2c.read(0, &mut buf).unwrap();
+        assert_eq!(buf, [0; 3]);
+    }
+
+    #[test]
+    fn i2c_read_some_data_set() {
+        let mut i2c = I2cMock::new();
+        let mut buf = [0; 3];
+        i2c.set_read_data(&[1, 2]);
+        i2c.read(0, &mut buf).unwrap();
+        assert_eq!(buf, [1, 2, 0]);
+    }
+
+    #[test]
+    fn i2c_read_too_much_data_set() {
+        let mut i2c = I2cMock::new();
+        let mut buf = [0; 3];
+        i2c.set_read_data(&[1, 2, 3, 4]);
+        i2c.read(0, &mut buf).unwrap();
+        assert_eq!(buf, [1, 2, 3]);
+    }
+
+    #[test]
+    fn i2c_write_data() {
+        let mut i2c = I2cMock::new();
+        let buf = [1, 2, 4];
+        assert_eq!(i2c.get_last_address(), None);
+        i2c.write(42, &buf[..]).unwrap();
+        assert_eq!(i2c.get_last_address(), Some(42));
+        assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
+        i2c.write(23, &buf[1..2]).unwrap();
+        assert_eq!(i2c.get_last_address(), Some(23));
+        assert_eq!(i2c.get_write_data(), &[2]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn i2c_write_data_too_much() {
+        let mut i2c = I2cMock::new();
+        let buf = [0; 65];
+        i2c.write(42, &buf[..]).unwrap();
+    }
+
+    #[test]
+    fn i2c_read_write_data() {
+        let mut i2c = I2cMock::new();
+        let buf = [1, 2, 4];
+        let mut buf2 = [0; 3];
+        assert_eq!(i2c.get_last_address(), None);
+        i2c.write_read(42, &buf[..], &mut buf2).unwrap();
+        assert_eq!(i2c.get_last_address(), Some(42));
+        assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
+    }
+}

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,11 +1,8 @@
-
-
-use std::io::{self, Read};
+use std::io::Read;
 
 use hal::blocking::i2c;
 
-use ::error::MockError;
-
+use error::MockError;
 
 const WRITE_BUF_SIZE: usize = 64;
 
@@ -57,8 +54,11 @@ impl<'a> i2c::Write for I2cMock<'a> {
 
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         if bytes.len() > WRITE_BUF_SIZE {
-            panic!("Write buffer is too small for this number of bytes ({} > {})",
-                   bytes.len(), WRITE_BUF_SIZE);
+            panic!(
+                "Write buffer is too small for this number of bytes ({} > {})",
+                bytes.len(),
+                WRITE_BUF_SIZE
+            );
         }
         self.address = Some(address);
         self.buf[0..bytes.len()].copy_from_slice(bytes);
@@ -77,8 +77,11 @@ impl<'a> i2c::WriteRead for I2cMock<'a> {
         mut buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
         if bytes.len() > WRITE_BUF_SIZE {
-            panic!("Write buffer is too small for this number of bytes ({} > {})",
-                   bytes.len(), WRITE_BUF_SIZE);
+            panic!(
+                "Write buffer is too small for this number of bytes ({} > {})",
+                bytes.len(),
+                WRITE_BUF_SIZE
+            );
         }
         self.address = Some(address);
         self.data.read(&mut buffer)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ mod i2c;
 pub use i2c::I2cMock;
 
 mod spi;
-pub use spi::Mock as SPIMock;
-pub use spi::Transaction as SPITransaction;
+pub use spi::Mock as SpiMock;
+pub use spi::Transaction as SpiTransaction;
 
 pub struct DelayMockNoop;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@ mod i2c;
 pub use i2c::I2cMock;
 
 mod spi;
-pub use spi::SPIMock;
+pub use spi::Mock as SPIMock;
+pub use spi::Transaction as SPITransaction;
 
 pub struct DelayMockNoop;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 extern crate embedded_hal as hal;
 
-use std::io::{self, Read};
-
 mod error;
 pub use error::MockError;
 
@@ -17,9 +15,9 @@ macro_rules! impl_delay_us {
     ($type:ty) => {
         impl hal::blocking::delay::DelayUs<$type> for DelayMockNoop {
             /// A no-op delay implementation.
-            fn delay_us(&mut self, _n: $type) { }
+            fn delay_us(&mut self, _n: $type) {}
         }
-    }
+    };
 }
 
 impl_delay_us!(u8);
@@ -31,14 +29,12 @@ macro_rules! impl_delay_ms {
     ($type:ty) => {
         impl hal::blocking::delay::DelayMs<$type> for DelayMockNoop {
             /// A no-op delay implementation.
-            fn delay_ms(&mut self, _n: $type) { }
+            fn delay_ms(&mut self, _n: $type) {}
         }
-    }
+    };
 }
 
 impl_delay_ms!(u8);
 impl_delay_ms!(u16);
 impl_delay_ms!(u32);
 impl_delay_ms!(u64);
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,97 +2,14 @@ extern crate embedded_hal as hal;
 
 use std::io::{self, Read};
 
-const WRITE_BUF_SIZE: usize = 64;
+mod error;
+pub use error::MockError;
 
-#[derive(Debug)]
-pub enum MockError {
-    Io(io::Error),
-}
+mod i2c;
+pub use i2c::I2cMock;
 
-impl From<io::Error> for MockError {
-    fn from(e: io::Error) -> Self {
-        MockError::Io(e)
-    }
-}
-
-pub struct I2cMock<'a> {
-    data: &'a [u8],
-    address: Option<u8>,
-    buf: [u8; WRITE_BUF_SIZE],
-    buf_bytes_written: usize,
-}
-
-impl<'a> I2cMock<'a> {
-    pub fn new() -> Self {
-        I2cMock {
-            data: &[],
-            address: None,
-            buf: [0; WRITE_BUF_SIZE],
-            buf_bytes_written: 0,
-        }
-    }
-
-    /// Set data that will be read by `read()`.
-    pub fn set_read_data(&mut self, data: &'a [u8]) {
-        self.data = data;
-    }
-
-    /// Return the data that was written by the last write command.
-    pub fn get_write_data(&self) -> &[u8] {
-        &self.buf[0..self.buf_bytes_written]
-    }
-
-    /// Return the address that was used by the last read or write command.
-    pub fn get_last_address(&self) -> Option<u8> {
-        self.address
-    }
-}
-
-impl<'a> hal::blocking::i2c::Read for I2cMock<'a> {
-    type Error = MockError;
-
-    fn read(&mut self, address: u8, mut buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.address = Some(address);
-        self.data.read(&mut buffer)?;
-        Ok(())
-    }
-}
-
-impl<'a> hal::blocking::i2c::Write for I2cMock<'a> {
-    type Error = MockError;
-
-    fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        if bytes.len() > WRITE_BUF_SIZE {
-            panic!("Write buffer is too small for this number of bytes ({} > {})",
-                   bytes.len(), WRITE_BUF_SIZE);
-        }
-        self.address = Some(address);
-        self.buf[0..bytes.len()].copy_from_slice(bytes);
-        self.buf_bytes_written = bytes.len();
-        Ok(())
-    }
-}
-
-impl<'a> hal::blocking::i2c::WriteRead for I2cMock<'a> {
-    type Error = MockError;
-
-    fn write_read(
-        &mut self,
-        address: u8,
-        bytes: &[u8],
-        mut buffer: &mut [u8],
-    ) -> Result<(), Self::Error> {
-        if bytes.len() > WRITE_BUF_SIZE {
-            panic!("Write buffer is too small for this number of bytes ({} > {})",
-                   bytes.len(), WRITE_BUF_SIZE);
-        }
-        self.address = Some(address);
-        self.data.read(&mut buffer)?;
-        self.buf[0..bytes.len()].copy_from_slice(bytes);
-        self.buf_bytes_written = bytes.len();
-        Ok(())
-    }
-}
+mod spi;
+pub use spi::SPIMock;
 
 pub struct DelayMockNoop;
 
@@ -124,67 +41,4 @@ impl_delay_ms!(u16);
 impl_delay_ms!(u32);
 impl_delay_ms!(u64);
 
-#[cfg(test)]
-mod tests {
-    use super::*;
 
-    use hal::blocking::i2c::{Read, Write, WriteRead};
-
-    #[test]
-    fn i2c_read_no_data_set() {
-        let mut i2c = I2cMock::new();
-        let mut buf = [0; 3];
-        i2c.read(0, &mut buf).unwrap();
-        assert_eq!(buf, [0; 3]);
-    }
-
-    #[test]
-    fn i2c_read_some_data_set() {
-        let mut i2c = I2cMock::new();
-        let mut buf = [0; 3];
-        i2c.set_read_data(&[1, 2]);
-        i2c.read(0, &mut buf).unwrap();
-        assert_eq!(buf, [1, 2, 0]);
-    }
-
-    #[test]
-    fn i2c_read_too_much_data_set() {
-        let mut i2c = I2cMock::new();
-        let mut buf = [0; 3];
-        i2c.set_read_data(&[1, 2, 3, 4]);
-        i2c.read(0, &mut buf).unwrap();
-        assert_eq!(buf, [1, 2, 3]);
-    }
-
-    #[test]
-    fn i2c_write_data() {
-        let mut i2c = I2cMock::new();
-        let buf = [1, 2, 4];
-        assert_eq!(i2c.get_last_address(), None);
-        i2c.write(42, &buf[..]).unwrap();
-        assert_eq!(i2c.get_last_address(), Some(42));
-        assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
-        i2c.write(23, &buf[1..2]).unwrap();
-        assert_eq!(i2c.get_last_address(), Some(23));
-        assert_eq!(i2c.get_write_data(), &[2]);
-    }
-
-    #[test]
-    #[should_panic]
-    fn i2c_write_data_too_much() {
-        let mut i2c = I2cMock::new();
-        let buf = [0; 65];
-        i2c.write(42, &buf[..]).unwrap();
-    }
-
-    #[test]
-    fn i2c_read_write_data() {
-        let mut i2c = I2cMock::new();
-        let buf = [1, 2, 4];
-        let mut buf2 = [0; 3];
-        assert_eq!(i2c.get_last_address(), None);
-        i2c.write_read(42, &buf[..], &mut buf2).unwrap();
-        assert_eq!(i2c.get_last_address(), Some(42));
-        assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
-    }
-}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -103,6 +103,7 @@ impl spi::Transfer<u8> for SPIMock {
             .expect("no expectation for spi::transfer call");
         assert_eq!(w.expected_mode, Mode::Transfer);
         assert_eq!(&w.expected_data, &buffer);
+        assert_eq!(buffer.len(), w.response.len(), "mismatched response length for spi::transfer");
         for i in 0..w.response.len() {
             buffer[i] = w.response[i];
         }
@@ -183,6 +184,24 @@ mod test {
         spi.expect(vec![Transaction::transfer(
             vec![10u8, 12u8],
             vec![12u8, 15u8],
+        )]);
+
+        let mut v = vec![10u8, 12u8];
+        spi.transfer(&mut v).unwrap();
+
+        assert_eq!(v, vec![12u8, 13u8]);
+
+        spi.done();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_spi_mock_transfer_response_err() {
+        let mut spi = SPIMock::new();
+
+        spi.expect(vec![Transaction::transfer(
+            vec![1u8, 2u8],
+            vec![3u8, 4u8, 5u8],
         )]);
 
         let mut v = vec![10u8, 12u8];

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,180 @@
+
+
+use std::io::{self, Read};
+use std::sync::{Arc, Mutex};
+
+use hal::blocking::spi;
+
+use ::error::MockError;
+
+/// SPI Transaction mode
+#[derive(Clone, Debug, PartialEq)]
+pub enum Mode {
+    None,
+    Write,
+    Transfer,
+}
+
+/// SPI transaction type
+#[derive(Clone, Debug, PartialEq)]
+pub struct Transaction {
+    expected_mode: Mode,
+    expected_data: Vec<u8>,
+    response: Vec<u8>,
+}
+
+impl Transaction {
+    /// Create a write transaction
+    pub fn write(expected: Vec<u8>) -> Transaction {
+        Transaction{
+            expected_mode: Mode::Write,
+            expected_data: expected,
+            response: Vec::new(),
+        }
+    }
+
+    /// Create a transfer transaction
+    pub fn transfer(expected: Vec<u8>, response: Vec<u8>) -> Transaction {
+        Transaction{
+            expected_mode: Mode::Transfer,
+            expected_data: expected,
+            response,
+        }
+    }
+}
+
+/// Mock SPI implementation
+pub struct SPIMock {
+    expected: Arc<Mutex<Vec<Transaction>>>,
+}
+
+impl SPIMock {
+    /// Create a new mock SPI interface
+    pub fn new() -> Self {
+        SPIMock { expected: Arc::new(Mutex::new(Vec::new())) }
+    }
+
+    /// Set expectations on the SPI interface
+    /// This is a list of SPI transactions to be executed
+    pub fn expect(&mut self, expected: Vec<Transaction>) {
+        let mut e = self.expected.lock().unwrap();
+        assert_eq!(e.len(), 0);
+        *e = expected;
+    }
+
+    pub fn check(&mut self) {
+        let expected = self.expected.lock().unwrap();
+        assert_eq!(expected.len(), 0);
+    }
+}
+
+impl spi::Write<u8> for SPIMock {
+    type Error = MockError;
+
+    fn write(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
+        let mut w = self.expected.lock().unwrap().pop().unwrap();
+        assert_eq!(w.expected_mode, Mode::Write);
+        assert_eq!(&w.expected_data, &buffer);
+        Ok(())
+    }
+}
+
+impl spi::Transfer<u8> for SPIMock {
+    type Error = MockError;
+
+    fn transfer<'w>(&mut self, buffer: &'w mut[u8]) -> Result<&'w [u8], Self::Error> {
+        let mut w = self.expected.lock().unwrap().pop().unwrap();
+        assert_eq!(w.expected_mode, Mode::Transfer);
+        assert_eq!(&w.expected_data, &buffer);
+        for i in 0..w.response.len() {
+            buffer[i] = w.response[i];
+        }
+        Ok(buffer)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use hal::blocking::spi::{Transfer, Write};
+
+    #[test]
+    fn test_spi_mock_write() {
+        let mut spi = SPIMock::new();
+
+        spi.expect(vec![Transaction::write(vec![10u8, 12u8])]);
+
+        spi.write(&vec![10u8, 12u8]).unwrap();
+
+        spi.check();
+    }
+
+    #[test]
+    fn test_spi_mock_transfer() {
+        let mut spi = SPIMock::new();
+
+        spi.expect(vec![Transaction::transfer(vec![10u8, 12u8], vec![12u8, 13u8])]);
+
+        let mut v = vec![10u8, 12u8];
+        spi.transfer(&mut v).unwrap();
+        
+        assert_eq!(v, vec![12u8, 13u8]);
+
+        spi.check();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_spi_mock_write_err() {
+        let mut spi = SPIMock::new();
+
+        spi.expect(vec![Transaction::write(vec![10u8, 12u8])]);
+
+        spi.write(&vec![10u8, 12u8, 12u8]).unwrap();
+
+        spi.check();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_spi_mock_transfer_err() {
+        let mut spi = SPIMock::new();
+
+        spi.expect(vec![Transaction::transfer(vec![10u8, 12u8], vec![12u8, 15u8])]);
+
+        let mut v = vec![10u8, 12u8];
+        spi.transfer(&mut v).unwrap();
+        
+        assert_eq!(v, vec![12u8, 13u8]);
+
+        spi.check();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_spi_mock_mode_err() {
+        let mut spi = SPIMock::new();
+
+        spi.expect(vec![Transaction::transfer(vec![10u8, 12u8], vec![])]);
+
+        spi.write(&vec![10u8, 12u8, 12u8]).unwrap();
+
+        spi.check();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_spi_mock_transaction_err() {
+        let mut spi = SPIMock::new();
+
+        spi.expect(vec![
+            Transaction::write(vec![10u8, 12u8]),
+            Transaction::write(vec![10u8, 12u8]),
+        ]);
+
+        spi.write(&vec![10u8, 12u8, 12u8]).unwrap();
+
+        spi.check();
+    }
+}


### PR DESCRIPTION
Hey there,

Thanks for making a neat thing! I added an SPI mock with transaction based expectations so that it works with more complex APIs (see also: https://github.com/rust-embedded/embedded-hal/issues/94 and https://github.com/rust-embedded/embedded-hal/issues/64). It does use vectors heavily, so is never going to be `no_std`, but I think it's pretty useful.

Let me know if you need any changes / I would also like to propose moving the I2C mock to this model.

Thanks,

Ryan