### PR TITLE
Updated i2c::Mock to use transaction based expectations

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -7,186 +7,325 @@
 //! extern crate embedded_hal_mock;
 //!
 //! use embedded_hal::prelude::*;
-//! use embedded_hal::blocking::i2c::Read;
-//! use embedded_hal_mock::i2c::Mock as I2cMock;
+//! use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
+//! use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTransaction};
 //!
 //! let mut i2c = I2cMock::new();
 //!
-//! // Reading
-//! let mut buf = [0; 3];
-//! i2c.set_read_data(&[1, 2]);
-//! i2c.read(0, &mut buf).unwrap();
-//! assert_eq!(buf, [1, 2, 0]);
-//! assert_eq!(i2c.get_last_address(), Some(0));
+//! // Configure expectations
+//! i2c.expect(vec![
+//!     I2cTransaction::write(0xaa, vec![1, 2]),
+//!     I2cTransaction::read(0xbb, vec![3, 4]),
+//! ]);
 //!
 //! // Writing
-//! let buf = [1, 2, 4];
-//! i2c.write(42, &buf).unwrap();
-//! assert_eq!(i2c.get_last_address(), Some(42));
-//! assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
+//! i2c.write(0xaa, &vec![1, 2]).unwrap();
+//!
+//! // Reading
+//! let mut buf = vec![0u8; 2];
+//! i2c.read(0xbb, &mut buf).unwrap();
+//! assert_eq!(buf, vec![3, 4]);
+//!
+//! // Finalise expectations
+//! i2c.done();
 //! ```
 
-use std::io::Read;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 
 use hal::blocking::i2c;
 
 use error::MockError;
 
-const WRITE_BUF_SIZE: usize = 64;
-
-/// Mock I²C implementation
-///
-/// The main idea behind this is that you set the data that will be read back
-/// by a read call in advance. Then the driver can read from the mock device,
-/// and will get exactly the data you prepared.
-///
-/// See the usage section in the module level docs for an example.
-pub struct Mock<'a> {
-    data: &'a [u8],
-    address: Option<u8>,
-    buf: [u8; WRITE_BUF_SIZE],
-    buf_bytes_written: usize,
+/// I2C Transaction modes
+#[derive(Clone, Debug, PartialEq)]
+pub enum Mode {
+    Write,
+    Read,
+    WriteRead,
 }
 
-impl<'a> Mock<'a> {
-    pub fn new() -> Self {
-        Mock {
-            data: &[],
-            address: None,
-            buf: [0; WRITE_BUF_SIZE],
-            buf_bytes_written: 0,
+/// I2C Transaction type
+/// 
+/// Models an I2C read or write
+#[derive(Clone, Debug, PartialEq)]
+pub struct Transaction {
+    expected_mode: Mode,
+    expected_addr: u8,
+    expected_data: Vec<u8>,
+    response_data: Vec<u8>,
+}
+
+impl Transaction {
+    /// Create a Write transaction
+    pub fn write(addr: u8, expected: Vec<u8>) -> Transaction {
+        Transaction {
+            expected_mode: Mode::Write,
+            expected_addr: addr,
+            expected_data: expected,
+            response_data: Vec::new(),
         }
     }
 
-    /// Set data that will be read by `read()`.
-    pub fn set_read_data(&mut self, data: &'a [u8]) {
-        self.data = data;
+    /// Create a Read transaction
+    pub fn read(addr: u8, response: Vec<u8>) -> Transaction {
+        Transaction {
+            expected_mode: Mode::Read,
+            expected_addr: addr,
+            expected_data: Vec::new(),
+            response_data: response,
+        }
     }
 
-    /// Return the data that was written by the last write command.
-    pub fn get_write_data(&self) -> &[u8] {
-        &self.buf[0..self.buf_bytes_written]
-    }
-
-    /// Return the address that was used by the last read or write command.
-    pub fn get_last_address(&self) -> Option<u8> {
-        self.address
+    /// Create a WriteRead transaction
+    pub fn write_read(addr: u8, expected: Vec<u8>, response: Vec<u8>) -> Transaction {
+        Transaction {
+            expected_mode: Mode::WriteRead,
+            expected_addr: addr,
+            expected_data: expected,
+            response_data: response,
+        }
     }
 }
 
-impl<'a> i2c::Read for Mock<'a> {
+/// Mock I2C implementation
+/// 
+/// This supports the specification and evaluation of expectations to allow automated testing of I2C based drivers.
+/// Mismatches between expectations will cause runtime assertions to assist in locating the source of the fault.
+pub struct Mock {
+    expected: Arc<Mutex<VecDeque<Transaction>>>,
+}
+
+impl Mock {
+    pub fn new() -> Self {
+        Mock {
+            expected: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    /// Set expectations on the I2C interface
+    /// 
+    /// This is a list of I2C transactions to be executed in order
+    /// Note that setting this will overwrite any existing expectations
+    pub fn expect(&mut self, expected: Vec<Transaction>) {
+        let mut e = self.expected.lock().unwrap();
+        *e = expected.into();
+    }
+
+    /// Assert that all expectations on a given Mock have been met
+    pub fn done(&mut self) {
+        let expected = self.expected.lock().unwrap();
+        assert_eq!(expected.len(), 0);
+    }
+}
+
+impl Clone for Mock {
+    fn clone(&self) -> Mock {
+        Mock{ expected: self.expected.clone() }
+    }
+}
+
+impl i2c::Read for Mock {
     type Error = MockError;
 
-    fn read(&mut self, address: u8, mut buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.address = Some(address);
-        self.data.read(&mut buffer)?;
+    fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        let w = self
+            .expected
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("no pending expectation for i2c::read call");
+
+        assert_eq!(w.expected_mode, Mode::Read, "i2c::read unexpected mode");
+        assert_eq!(w.expected_addr, address, "i2c::read address mismatch");
+
+        assert_eq!(buffer.len(), w.response_data.len(), "i2c:read mismatched response length");
+        buffer.copy_from_slice(&w.response_data);
+
         Ok(())
     }
 }
 
-impl<'a> i2c::Write for Mock<'a> {
+impl i2c::Write for Mock {
     type Error = MockError;
 
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        if bytes.len() > WRITE_BUF_SIZE {
-            panic!(
-                "Write buffer is too small for this number of bytes ({} > {})",
-                bytes.len(),
-                WRITE_BUF_SIZE
-            );
-        }
-        self.address = Some(address);
-        self.buf[0..bytes.len()].copy_from_slice(bytes);
-        self.buf_bytes_written = bytes.len();
+        let w = self
+            .expected
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("no pending expectation for i2c::read call");
+            
+        assert_eq!(w.expected_mode, Mode::Write, "i2c::write unexpected mode");
+        assert_eq!(w.expected_addr, address, "i2c::write address mismatch");
+        assert_eq!(w.expected_data, bytes, "i2c::write data does not match expectation");
+
         Ok(())
     }
 }
 
-impl<'a> i2c::WriteRead for Mock<'a> {
+impl i2c::WriteRead for Mock {
     type Error = MockError;
 
     fn write_read(
         &mut self,
         address: u8,
         bytes: &[u8],
-        mut buffer: &mut [u8],
+        buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
-        if bytes.len() > WRITE_BUF_SIZE {
-            panic!(
-                "Write buffer is too small for this number of bytes ({} > {})",
-                bytes.len(),
-                WRITE_BUF_SIZE
-            );
-        }
-        self.address = Some(address);
-        self.data.read(&mut buffer)?;
-        self.buf[0..bytes.len()].copy_from_slice(bytes);
-        self.buf_bytes_written = bytes.len();
+        let w = self
+            .expected
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("no pending expectation for i2c::read call");
+            
+        assert_eq!(w.expected_mode, Mode::WriteRead, "i2c::write_read unexpected mode");
+        assert_eq!(w.expected_addr, address, "i2c::write_read address mismatch");
+        assert_eq!(w.expected_data, bytes, "i2c::write_read write data does not match expectation");
+
+        assert_eq!(buffer.len(), w.response_data.len(), "i2c::write_read mismatched response length");
+        buffer.copy_from_slice(&w.response_data);
+
         Ok(())
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     use hal::blocking::i2c::{Read, Write, WriteRead};
 
     #[test]
-    fn i2c_read_no_data_set() {
+    fn test_i2c_mock_write() {
         let mut i2c = Mock::new();
-        let mut buf = [0; 3];
-        i2c.read(0, &mut buf).unwrap();
-        assert_eq!(buf, [0; 3]);
+
+        i2c.expect(vec![Transaction::write(0xaa, vec![10, 12])]);
+
+        i2c.write(0xaa, &vec![10, 12]).unwrap();
+
+        i2c.done();
     }
 
     #[test]
-    fn i2c_read_some_data_set() {
+    fn test_i2c_mock_read() {
         let mut i2c = Mock::new();
-        let mut buf = [0; 3];
-        i2c.set_read_data(&[1, 2]);
-        i2c.read(0, &mut buf).unwrap();
-        assert_eq!(buf, [1, 2, 0]);
+
+        i2c.expect(vec![Transaction::read(0xaa, vec![1, 2])]);
+
+        let mut buff = vec![0u8; 2];
+        i2c.read(0xaa, &mut buff).unwrap();
+        assert_eq!(vec![1, 2], buff);
+
+        i2c.done();
     }
 
     #[test]
-    fn i2c_read_too_much_data_set() {
+    fn test_i2c_mock_write_read() {
         let mut i2c = Mock::new();
-        let mut buf = [0; 3];
-        i2c.set_read_data(&[1, 2, 3, 4]);
-        i2c.read(0, &mut buf).unwrap();
-        assert_eq!(buf, [1, 2, 3]);
+
+        i2c.expect(vec![Transaction::write_read(0xaa,
+            vec![1, 2],
+            vec![3, 4],
+        )]);
+
+        let v = vec![1, 2];
+        let mut buff = vec![0u8; 2];
+        i2c.write_read(0xaa, &v, &mut buff).unwrap();
+        assert_eq!(vec![3, 4], buff);
+
+        i2c.done();
     }
 
     #[test]
-    fn i2c_write_data() {
+    fn test_i2c_mock_multiple() {
         let mut i2c = Mock::new();
-        let buf = [1, 2, 4];
-        assert_eq!(i2c.get_last_address(), None);
-        i2c.write(42, &buf[..]).unwrap();
-        assert_eq!(i2c.get_last_address(), Some(42));
-        assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
-        i2c.write(23, &buf[1..2]).unwrap();
-        assert_eq!(i2c.get_last_address(), Some(23));
-        assert_eq!(i2c.get_write_data(), &[2]);
+
+        i2c.expect(vec![
+            Transaction::write(0xaa, vec![1, 2]),
+            Transaction::read(0xbb, vec![3, 4]),
+        ]);
+
+        i2c.write(0xaa, &vec![1, 2]).unwrap();
+
+        let mut v = vec![0u8; 2];
+        i2c.read(0xbb, &mut v).unwrap();
+
+        assert_eq!(v, vec![3, 4]);
+
+        i2c.done();
     }
 
     #[test]
     #[should_panic]
-    fn i2c_write_data_too_much() {
+    fn test_i2c_mock_write_err() {
         let mut i2c = Mock::new();
-        let buf = [0; 65];
-        i2c.write(42, &buf[..]).unwrap();
+
+        i2c.expect(vec![Transaction::write(0xaa, vec![1, 2])]);
+
+        i2c.write(0xaa, &vec![1, 3]).unwrap();
+
+        i2c.done();
     }
 
     #[test]
-    fn i2c_read_write_data() {
+    #[should_panic]
+    fn test_i2c_mock_read_err() {
         let mut i2c = Mock::new();
-        let buf = [1, 2, 4];
-        let mut buf2 = [0; 3];
-        assert_eq!(i2c.get_last_address(), None);
-        i2c.write_read(42, &buf[..], &mut buf2).unwrap();
-        assert_eq!(i2c.get_last_address(), Some(42));
-        assert_eq!(i2c.get_write_data(), &[1, 2, 4]);
+
+        i2c.expect(vec![Transaction::read(0xaa, vec![10, 12])]);
+
+        let mut buff = vec![0u8; 2];
+        i2c.write(0xaa, &mut buff).unwrap();
+        assert_eq!(vec![10, 12], buff);
+
+        i2c.done();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_i2c_mock_write_read_err() {
+        let mut i2c = Mock::new();
+
+        i2c.expect(vec![Transaction::write_read(0xbb,
+            vec![1, 2],
+            vec![3, 4],
+        )]);
+
+        let v = vec![1, 2];
+        let mut buff = vec![0u8; 2];
+        i2c.write_read(0xaa, &v, &mut buff).unwrap();
+        assert_eq!(vec![3, 4], buff);
+
+        i2c.done();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_i2c_mock_mode_err() {
+        let mut i2c = Mock::new();
+
+        i2c.expect(vec![Transaction::read(0xaa, vec![10, 12])]);
+
+        i2c.write(0xaa, &vec![10, 12]).unwrap();
+
+        i2c.done();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_i2c_mock_multiple_transaction_err() {
+        let mut i2c = Mock::new();
+
+        i2c.expect(vec![
+            Transaction::write(0xaa, vec![10, 12]),
+            Transaction::write(0xaa, vec![10, 12]),
+        ]);
+
+        i2c.write(0xaa, &vec![10, 12]).unwrap();
+
+        i2c.done();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ extern crate embedded_hal as hal;
 mod error;
 pub use error::MockError;
 
+pub mod mock;
 pub mod i2c;
 pub mod spi;
 pub mod delay;
+

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -2,9 +2,13 @@
 use std::sync::{Mutex, Arc};
 
 /// Generic Mock implementation
-/// 
+///
 /// This supports the specification and evaluation of expectations to allow automated testing of hal drivers.
 /// Mismatches between expectations will cause runtime assertions to assist in locating the source of the fault.
+///
+/// Note that the implementation uses an `Arc<Mutex<...>>` internally, so a
+/// cloned instance of the mock can be used to check the expectations of the
+/// original instance that has been moved into a driver.
 #[derive(Debug)]
 pub struct Generic<'a, T: 'a> {
     expected: Arc<Mutex<(usize, &'a[T])>>,
@@ -12,7 +16,7 @@ pub struct Generic<'a, T: 'a> {
 
 impl <'a, T>Generic<'a, T> {
     /// Create a new mock interface
-    /// 
+    ///
     /// This creates a new generic mock interface with initial expectations
     pub fn new(e: &'a [T]) -> Self {
         Generic {
@@ -21,7 +25,7 @@ impl <'a, T>Generic<'a, T> {
     }
 
     /// Set expectations on the interface
-    /// 
+    ///
     /// This is a list of transactions to be executed in order
     /// Note that setting this will overwrite any existing expectations
     pub fn expect(&mut self, expected: &'a [T]) {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,0 +1,70 @@
+
+use std::sync::{Mutex, Arc};
+
+/// Generic Mock implementation
+/// 
+/// This supports the specification and evaluation of expectations to allow automated testing of hal drivers.
+/// Mismatches between expectations will cause runtime assertions to assist in locating the source of the fault.
+#[derive(Debug)]
+pub struct Generic<'a, T: 'a> {
+    expected: Arc<Mutex<(usize, &'a[T])>>,
+}
+
+impl <'a, T>Generic<'a, T> {
+    /// Create a new mock interface
+    /// 
+    /// This creates a new generic mock interface with initial expectations
+    pub fn new(e: &'a [T]) -> Self {
+        Generic {
+            expected: Arc::new(Mutex::new((0, e))),
+        }
+    }
+
+    /// Set expectations on the interface
+    /// 
+    /// This is a list of transactions to be executed in order
+    /// Note that setting this will overwrite any existing expectations
+    pub fn expect(&mut self, expected: &'a [T]) {
+        let mut e = self.expected.lock().unwrap();
+        e.0 = 0;
+        e.1 = expected.into();
+    }
+
+    /// Assert that all expectations on a given Mock have been met
+    pub fn done(&mut self) {
+        let e = self.expected.lock().unwrap();
+        assert_eq!(e.0, e.1.len());
+    }
+}
+
+/// Clone allows a single mock to be duplicated for control and evaluation
+impl <'a, T>Clone for Generic<'a, T> {
+    fn clone(&self) -> Self {
+        Generic{ expected: self.expected.clone() }
+    }
+}
+
+/// Iterator impl for use in mock impls
+impl <'a, T>Iterator for Generic<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut e = self.expected.lock().unwrap();
+        e.0 += 1;
+        e.1.get(e.0-1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mock::Generic;
+
+    #[test]
+    fn test_generic_mock() {
+        let expectations = [0u8, 1u8];
+        let mut mock = Generic::new(&expectations);
+
+        assert_eq!(mock.next(), Some(&0u8));
+        assert_eq!(mock.next(), Some(&1u8));
+        assert_eq!(mock.next(), None);
+    }
+}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -19,7 +19,7 @@
 //!     SpiTransaction::write(vec![1, 2]),
 //!     SpiTransaction::transfer(vec![3, 4], vec![5, 6]),
 //! ];
-//! 
+//!
 //! let mut spi = SpiMock::new(&expectations);
 //!
 //! // Writing

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -14,13 +14,13 @@
 //! use embedded_hal::blocking::spi::{Transfer, Write};
 //! use embedded_hal_mock::spi::{Mock as SpiMock, Transaction as SpiTransaction};
 //!
-//! let mut spi = SpiMock::new();
-//!
 //! // Configure expectations
-//! spi.expect(vec![
+//! let expectations = [
 //!     SpiTransaction::write(vec![1, 2]),
 //!     SpiTransaction::transfer(vec![3, 4], vec![5, 6]),
-//! ]);
+//! ];
+//! 
+//! let mut spi = SpiMock::new(&expectations);
 //!
 //! // Writing
 //! spi.write(&vec![1, 2]).unwrap();
@@ -34,11 +34,9 @@
 //! spi.done();
 //! ```
 
-use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
-
 use hal::blocking::spi;
 
+use mock::Generic;
 use error::MockError;
 
 /// SPI Transaction mode
@@ -86,76 +84,34 @@ impl Transaction {
 /// faults.
 ///
 /// See the usage section in the module level docs for an example.
-pub struct Mock {
-    expected: Arc<Mutex<VecDeque<Transaction>>>,
-}
+pub type Mock<'a> = Generic<'a, Transaction>;
 
-impl Mock {
-    /// Create a new mock SPI interface
-    pub fn new() -> Self {
-        Mock {
-            expected: Arc::new(Mutex::new(VecDeque::new())),
-        }
-    }
-
-    /// Set expectations on the SPI interface
-    ///
-    /// This is a list of SPI transactions to be executed in order
-    /// Note that setting this will overwrite any existing expectations
-    pub fn expect(&mut self, expected: Vec<Transaction>) {
-        let mut e = self.expected.lock().unwrap();
-        *e = expected.into();
-    }
-
-    /// Assert that all expectations on a given Mock have been met
-    pub fn done(&mut self) {
-        let expected = self.expected.lock().unwrap();
-        assert_eq!(expected.len(), 0);
-    }
-}
-
-impl Clone for Mock {
-    fn clone(&self) -> Mock {
-        Mock{ expected: self.expected.clone() }
-    }
-}
-
-impl spi::Write<u8> for Mock {
+impl <'a>spi::Write<u8> for Mock<'a> {
     type Error = MockError;
 
     /// spi::Write implementation for Mock
     ///
     /// This will cause an assertion if the write call does not match the next expectation
     fn write(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
-        let w = self
-            .expected
-            .lock()
-            .unwrap()
-            .pop_front()
-            .expect("no expectation for spi::write call");
+        let w = self.next().expect("no expectation for spi::write call");
         assert_eq!(w.expected_mode, Mode::Write, "spi::write unexpected mode");
         assert_eq!(&w.expected_data, &buffer, "spi::write data does not match expectation");
         Ok(())
     }
 }
 
-impl spi::Transfer<u8> for Mock {
+impl <'a>spi::Transfer<u8> for Mock<'a> {
     type Error = MockError;
 
     /// spi::Transfer implementation for Mock
     ///
     /// This writes the provided response to the buffer and will cause an assertion if the written data does not match the next expectation
     fn transfer<'w>(&mut self, buffer: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
-        let w = self
-            .expected
-            .lock()
-            .unwrap()
-            .pop_front()
-            .expect("no expectation for spi::transfer call");
+        let w = self.next().expect("no expectation for spi::transfer call");
         assert_eq!(w.expected_mode, Mode::Transfer, "spi::transfer unexpected mode");
         assert_eq!(&w.expected_data, &buffer, "spi::write data does not match expectation");
         assert_eq!(buffer.len(), w.response.len(), "mismatched response length for spi::transfer");
-        buffer.copy_from_slice(&w.responsea);
+        buffer.copy_from_slice(&w.response);
         Ok(buffer)
     }
 }
@@ -168,9 +124,8 @@ mod test {
 
     #[test]
     fn test_spi_mock_write() {
-        let mut spi = Mock::new();
-
-        spi.expect(vec![Transaction::write(vec![10, 12])]);
+        let expectations = [Transaction::write(vec![10, 12])];
+        let mut spi = Mock::new(&expectations);
 
         spi.write(&vec![10, 12]).unwrap();
 
@@ -179,12 +134,11 @@ mod test {
 
     #[test]
     fn test_spi_mock_transfer() {
-        let mut spi = Mock::new();
-
-        spi.expect(vec![Transaction::transfer(
+        let expectations = [Transaction::transfer(
             vec![10, 12],
             vec![12, 13],
-        )]);
+        )];
+        let mut spi = Mock::new(&expectations);
 
         let mut v = vec![10, 12];
         spi.transfer(&mut v).unwrap();
@@ -196,12 +150,11 @@ mod test {
 
     #[test]
     fn test_spi_mock_multiple() {
-        let mut spi = Mock::new();
-
-        spi.expect(vec![
+        let expectations = [
             Transaction::write(vec![1, 2]),
             Transaction::transfer(vec![3, 4], vec![5, 6]),
-        ]);
+        ];
+        let mut spi = Mock::new(&expectations);
 
         spi.write(&vec![1, 2]).unwrap();
 
@@ -216,9 +169,8 @@ mod test {
     #[test]
     #[should_panic]
     fn test_spi_mock_write_err() {
-        let mut spi = Mock::new();
-
-        spi.expect(vec![Transaction::write(vec![10, 12])]);
+        let expectations = [Transaction::write(vec![10, 12])];
+        let mut spi = Mock::new(&expectations);
 
         spi.write(&vec![10, 12, 12]).unwrap();
 
@@ -228,12 +180,11 @@ mod test {
     #[test]
     #[should_panic]
     fn test_spi_mock_transfer_err() {
-        let mut spi = Mock::new();
-
-        spi.expect(vec![Transaction::transfer(
+        let expectations = [Transaction::transfer(
             vec![10, 12],
             vec![12, 15],
-        )]);
+        )];
+        let mut spi = Mock::new(&expectations);
 
         let mut v = vec![10, 12];
         spi.transfer(&mut v).unwrap();
@@ -246,12 +197,11 @@ mod test {
     #[test]
     #[should_panic]
     fn test_spi_mock_transfer_response_err() {
-        let mut spi = Mock::new();
-
-        spi.expect(vec![Transaction::transfer(
+        let expectations = [Transaction::transfer(
             vec![1, 2],
             vec![3, 4, 5],
-        )]);
+        )];
+        let mut spi = Mock::new(&expectations);
 
         let mut v = vec![10, 12];
         spi.transfer(&mut v).unwrap();
@@ -264,9 +214,8 @@ mod test {
     #[test]
     #[should_panic]
     fn test_spi_mock_mode_err() {
-        let mut spi = Mock::new();
-
-        spi.expect(vec![Transaction::transfer(vec![10, 12], vec![])]);
+        let expectations = [Transaction::transfer(vec![10, 12], vec![])];
+let mut spi = Mock::new(&expectations);
 
         spi.write(&vec![10, 12, 12]).unwrap();
 
@@ -276,12 +225,12 @@ mod test {
     #[test]
     #[should_panic]
     fn test_spi_mock_multiple_transaction_err() {
-        let mut spi = Mock::new();
+        let expectations = [
+            Transaction::write(vec![10, 12]),
+            Transaction::write(vec![10, 12]),
+        ];
+        let mut spi = Mock::new(&expectations);
 
-        spi.expect(vec![
-            Transaction::write(vec![10, 12]),
-            Transaction::write(vec![10, 12]),
-        ]);
 
         spi.write(&vec![10, 12, 12]).unwrap();
 


### PR DESCRIPTION
I'm not sure how you feel about breaking changes to the existing mocks, but I rebuild I2C to work along the same lines as the SPI mocks just merged.