### PR TITLE
Spidev added spi FullDuplex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ include = [
 
 [dependencies]
 embedded-hal = "0.2"
+nb = "0.1.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -38,7 +38,7 @@ impl <'a, T>Generic<'a, T> {
     /// Assert that all expectations on a given Mock have been met
     pub fn done(&mut self) {
         let e = self.expected.lock().unwrap();
-        assert_eq!(e.0, e.1.len());
+        assert_eq!(e.0, e.1.len(),"Mock call number(left) and expectations(right) do not match");
     }
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -33,8 +33,9 @@
 //! // Finalise expectations
 //! spi.done();
 //! ```
-
+extern crate nb;
 use hal::blocking::spi;
+use hal::spi::FullDuplex;
 
 use common::Generic;
 use error::MockError;
@@ -46,6 +47,10 @@ pub enum Mode {
     Write,
     /// Write and read transaction
     Transfer,
+    /// Send transaction
+    Send,
+    /// After a send transaction in real HW a Read is available
+    Read,
 }
 
 /// SPI transaction type
@@ -73,7 +78,23 @@ impl Transaction {
         Transaction {
             expected_mode: Mode::Transfer,
             expected_data: expected,
-            response,
+            response: response,
+        }
+    }
+    /// Create a transfer transaction
+    pub fn send(expected: u8 ) -> Transaction {
+        Transaction {
+            expected_mode: Mode::Send,
+            expected_data: [expected].to_vec(),
+            response: Vec::new(),
+        }
+    }
+    /// Create a transfer transaction
+    pub fn read(response: u8) -> Transaction {
+        Transaction {
+            expected_mode: Mode::Read,
+            expected_data: Vec::new(),
+            response: [response].to_vec(),
         }
     }
 }
@@ -102,6 +123,31 @@ impl <'a>spi::Write<u8> for Mock<'a> {
     }
 }
 
+impl <'a>FullDuplex<u8> for Mock<'a> {
+    type Error = MockError;
+    /// spi::FullDuplex implementeation for Mock
+    ///
+    /// This will call the nonblocking read/write primitives.
+
+    fn send(&mut self, buffer: u8) -> nb::Result<(), Self::Error> {
+        let data = self.next().expect("no expectation for spi::send call");
+        assert_eq!(data.expected_mode, Mode::Send, "spi::send unexpected mode");
+        assert_eq!(data.expected_data[0], buffer, "spi::send data does not match expectation");
+        Ok(())
+    }
+    /// spi::FullDuplex implementeation for Mock
+    ///
+    /// This will call the nonblocking read/write primitives.
+
+    fn read(&mut self) -> nb::Result< u8, Self::Error> {
+        let w = self.next().expect("no expectation for spi::read call");
+        assert_eq!(w.expected_mode, Mode::Read, "spi::Read unexpected mode");
+        assert_eq!(1, w.response.len(), "mismatched response length for spi::read");
+        let buffer:u8 = w.response[0];
+        Ok(buffer)
+    }
+
+}
 impl <'a>spi::Transfer<u8> for Mock<'a> {
     type Error = MockError;
 
@@ -123,6 +169,57 @@ mod test {
     use super::*;
 
     use hal::blocking::spi::{Transfer, Write};
+
+    #[test]
+    fn test_spi_mock_send() {
+        let expectations = [Transaction::send(10)];
+        let mut spi = Mock::new(&expectations);
+
+        spi.send(10).unwrap();
+
+        spi.done();
+    }
+
+    #[test]
+    fn test_spi_mock_read() {
+        let expectations = [Transaction::read(10)];
+
+        let mut spi = Mock::new(&expectations);
+
+        let ans=spi.read().unwrap();
+
+        assert_eq!(ans, 10);
+
+        spi.done();
+    }
+
+    #[test]
+    fn test_spi_mock_multiple1() {
+        let expectations = [
+            Transaction::write(vec![1, 2]),
+            Transaction::send(9),
+            Transaction::read(10),
+            Transaction::send(0xFE),
+            Transaction::read(0xFF),
+            Transaction::transfer(vec![3, 4], vec![5, 6]),
+
+        ];
+        let mut spi = Mock::new(&expectations);
+
+        spi.write(&vec![1, 2]).unwrap();
+
+
+        spi.send(0x09);
+        assert_eq!(spi.read().unwrap(), 0x0a);
+        spi.send(0xfe);
+        assert_eq!(spi.read().unwrap(), 0xFF);
+        let mut v = vec![3, 4];
+        spi.transfer(&mut v).unwrap();
+
+        assert_eq!(v, vec![5, 6]);
+
+        spi.done();
+    }
 
     #[test]
     fn test_spi_mock_write() {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -15,11 +15,10 @@
 //! use embedded_hal_mock::spi::{Mock as SpiMock, Transaction as SpiTransaction};
 //! use embedded_hal::spi::FullDuplex;
 //! 
-
 //! // Configure expectations
 //! let expectations = [
-//!     SpiTransaction::send(9),
-//!     SpiTransaction::read(10),
+//!     SpiTransaction::send(0x09),
+//!     SpiTransaction::read(0x0A),
 //!     SpiTransaction::send(0xFE),
 //!     SpiTransaction::read(0xFF),
 //!     SpiTransaction::write(vec![1, 2]),
@@ -29,8 +28,8 @@
 //! let mut spi = SpiMock::new(&expectations);
 //! // FullDuplex transfers
 //! spi.send(0x09);
-//! assert_eq!(spi.read().unwrap(), 0x0a);
-//! spi.send(0xfe);
+//! assert_eq!(spi.read().unwrap(), 0x0A);
+//! spi.send(0xFE);
 //! assert_eq!(spi.read().unwrap(), 0xFF);
 //! 
 //! // Writing


### PR DESCRIPTION
Happy New Year!

Added implementation for single byte send/read via the non blocking embedded_hal::spi::FullDuplex trait.

Limitations: Unit test must be updated when changing from a implementation based on read() and write() calls to one with transfer calls as they do not share data.