### PR TITLE
Add badge with minimum rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # embedded-hal-mock
 
 [![CircleCI][circle-ci-badge]][circle-ci]
+![Minimum Rust Version][min-rust-badge]
 
 This is a collection of types that implement the embedded-hal traits.
 
@@ -72,3 +73,4 @@ be dual licensed as above, without any additional terms or conditions.
 <!-- Badges -->
 [circle-ci]: https://circleci.com/gh/dbrgn/embedded-hal-mock/tree/master
 [circle-ci-badge]: https://circleci.com/gh/dbrgn/embedded-hal-mock/tree/master.svg?style=shield
+[min-rust-badge]: https://img.shields.io/badge/rustc-1.31+-lightgray.svg

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ be dual licensed as above, without any additional terms or conditions.
 <!-- Badges -->
 [circle-ci]: https://circleci.com/gh/dbrgn/embedded-hal-mock/tree/master
 [circle-ci-badge]: https://circleci.com/gh/dbrgn/embedded-hal-mock/tree/master.svg?style=shield
-[min-rust-badge]: https://img.shields.io/badge/rustc-1.31+-lightgray.svg
+[min-rust-badge]: https://img.shields.io/badge/rustc-1.31+-blue.svg


### PR DESCRIPTION
Here the PR adding the badge for minimum rust version. There are different colors to choose from, though.