### PR TITLE
Mock Pin impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,3 @@ edition = "2018"
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 nb = "0.1.1"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = { version = "0.2.2", features = ["unproven"] }
+embedded-hal = { version = "0.2.3-rc.1", features = ["unproven"] }
 nb = "0.1.1"
-
-[patch.crates-io]
-embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,9 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2"
+embedded-hal = { version = "0.2.2", features = ["unproven"] }
 nb = "0.1.1"
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = { version = "0.2.3-rc.1", features = ["unproven"] }
+embedded-hal = { version = "0.2.3", features = ["unproven"] }
 nb = "0.1.1"
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This crate requires Rust 1.31+!
 - [x] Actual delay
 - [x] Serial
 - [ ] RNG
-- [ ] I/O pins
+- [x] I/O pins
 - [ ] Timers
 - [ ] ...
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,14 @@
 use std::io;
 
 /// Errors that may occur during mocking.
-#[derive(Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum MockError {
     /// An I/O-Error occurred
-    Io(io::Error),
+    Io(io::ErrorKind),
 }
 
 impl From<io::Error> for MockError {
     fn from(e: io::Error) -> Self {
-        MockError::Io(e)
+        MockError::Io(e.kind())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,4 @@ pub mod delay;
 pub mod i2c;
 pub mod serial;
 pub mod spi;
+pub mod pin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,6 @@ pub use crate::error::MockError;
 pub mod common;
 pub mod delay;
 pub mod i2c;
+pub mod pin;
 pub mod serial;
 pub mod spi;
-pub mod pin;

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -97,10 +97,10 @@ impl TransactionKind {
 }
 
 /// Mock Pin implementation
-pub type Mock<'a> = Generic<'a, Transaction>;
+pub type Mock = Generic<Transaction>;
 
 /// Single digital push-pull output pin
-impl <'a>OutputPin for Mock<'a> {
+impl OutputPin for Mock {
     /// Error type
     type Error = MockError;
 
@@ -108,7 +108,7 @@ impl <'a>OutputPin for Mock<'a> {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         let Transaction{kind, err} = self.next().expect("no expectation for pin::set_low call");
 
-        assert_eq!(*kind, TransactionKind::Set(false), "expected pin::set_low");
+        assert_eq!(kind, TransactionKind::Set(false), "expected pin::set_low");
         
         match err {
             Some(e) => Err(e.clone()),
@@ -120,7 +120,7 @@ impl <'a>OutputPin for Mock<'a> {
     fn set_high(&mut self) -> Result<(), Self::Error> {
         let Transaction{kind, err} = self.next().expect("no expectation for pin::set_high call");
 
-        assert_eq!(*kind, TransactionKind::Set(true), "expected pin::set_high");
+        assert_eq!(kind, TransactionKind::Set(true), "expected pin::set_high");
         
         match err {
             Some(e) => Err(e.clone()),
@@ -129,7 +129,7 @@ impl <'a>OutputPin for Mock<'a> {
     }
 }
 
-impl <'a>InputPin for Mock<'a> {
+impl InputPin for Mock {
     /// Error type
     type Error = MockError;
 
@@ -144,7 +144,7 @@ impl <'a>InputPin for Mock<'a> {
         if let Some(e) = err { 
             Err(e.clone())
         } else if let TransactionKind::Get(v) = kind {
-            Ok(*v == true)
+            Ok(v == true)
         } else {
             unreachable!();
         }
@@ -161,7 +161,7 @@ impl <'a>InputPin for Mock<'a> {
         if let Some(e) = err { 
             Err(e.clone())
         } else if let TransactionKind::Get(v) = kind {
-            Ok(*v == false)
+            Ok(v == false)
         } else {
             unreachable!();
         }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,0 +1,219 @@
+//! Mock digital InputPin and OutputPin implementations
+//! 
+//! ```
+//! use std::io::ErrorKind;
+//! 
+//! use embedded_hal_mock::MockError;
+//! use embedded_hal_mock::pin::{Transaction as PinTransaction, Mock as MockPin};
+//! use embedded_hal::digital::v2::{InputPin, OutputPin};
+//! 
+//! let err = MockError::Io(ErrorKind::NotConnected);
+//! 
+//! // Configure expectations
+//! let expectations = [
+//!     PinTransaction::get(true),
+//!     PinTransaction::get(true),
+//!     PinTransaction::set(false),
+//!     PinTransaction::set(true).with_error(err.clone()),
+//! ];
+//! 
+//! // Create pin
+//! let mut pin = MockPin::new(&expectations);
+//! 
+//! // Run and test
+//! assert_eq!(pin.is_high().unwrap(), true);
+//! assert_eq!(pin.is_low().unwrap(), false);
+//! 
+//! pin.set_low().unwrap();
+//! pin.set_high().expect_err("expected error return");
+//! 
+//! pin.done();
+//! 
+//! // Update expectations
+//! pin.expect(&[]);
+//! // ...
+//! pin.done();
+//! 
+//! ```
+
+
+use crate::common::Generic;
+use crate::error::MockError;
+
+use embedded_hal::digital::v2::{OutputPin, InputPin};
+
+/// MockPin transaction
+#[derive(PartialEq, Clone, Debug)]
+pub struct Transaction {
+    /// Kind is the transaction kind (and data) expected
+    kind: TransactionKind,
+    /// Err is an optional error return for a transaction.
+    /// This is in addition to kind to allow validation that the transaction kind
+    /// is correct prior to returning the error.
+    err: Option<MockError>,
+}
+
+impl Transaction {
+    /// Create a new pin transaction
+    pub fn new(kind: TransactionKind) -> Transaction {
+        Transaction{kind, err: None}
+    }
+
+    /// Create a new get transaction
+    pub fn get(value: bool) -> Transaction {
+        Transaction::new(TransactionKind::Get(value))
+    }
+
+    /// Create a new get transaction
+    pub fn set(value: bool) -> Transaction {
+        Transaction::new(TransactionKind::Set(value))
+    }
+
+    /// Add an error return to a transaction
+    /// This is used to mock failure behaviours
+    pub fn with_error(self, error: MockError) -> Self {
+        let mut t = self;
+        t.err = Some(error);
+        t
+    }
+}
+
+/// MockPin transaction kind, either Get or Set a bool
+#[derive(PartialEq, Clone, Debug)]
+pub enum TransactionKind {
+    /// Set(true) for set_high or Set(false) for set_low
+    Set(bool),
+    /// Get(true) for high value or Get(false) for low value
+    Get(bool),
+}
+
+impl TransactionKind {
+    fn is_get(&self) -> bool {
+        match self {
+            TransactionKind::Get(_) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Mock Pin implementation
+pub type Mock<'a> = Generic<'a, Transaction>;
+
+/// Single digital push-pull output pin
+impl <'a>OutputPin for Mock<'a> {
+    /// Error type
+    type Error = MockError;
+
+    /// Drives the pin low
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        let Transaction{kind, err} = self.next().expect("no expectation for pin::set_low call");
+
+        assert_eq!(*kind, TransactionKind::Set(false), "expected pin::set_low");
+        
+        match err {
+            Some(e) => Err(e.clone()),
+            None => Ok(()),
+        }
+    }
+
+    /// Drives the pin high
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        let Transaction{kind, err} = self.next().expect("no expectation for pin::set_high call");
+
+        assert_eq!(*kind, TransactionKind::Set(true), "expected pin::set_high");
+        
+        match err {
+            Some(e) => Err(e.clone()),
+            None => Ok(()),
+        }
+    }
+}
+
+impl <'a>InputPin for Mock<'a> {
+    /// Error type
+    type Error = MockError;
+
+    /// Is the input pin high?
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        let mut s = self.clone();
+
+        let Transaction{kind, err} = s.next().expect("no expectation for pin::is_high call");
+
+        assert_eq!(kind.is_get(), true, "expected pin::get");
+
+        if let Some(e) = err { 
+            Err(e.clone())
+        } else if let TransactionKind::Get(v) = kind {
+            Ok(*v == true)
+        } else {
+            unreachable!();
+        }
+    }
+
+    /// Is the input pin low?
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        let mut s = self.clone();
+
+        let Transaction{kind, err} = s.next().expect("no expectation for pin::is_low call");
+
+        assert_eq!(kind.is_get(), true, "expected pin::get");
+
+        if let Some(e) = err { 
+            Err(e.clone())
+        } else if let TransactionKind::Get(v) = kind {
+            Ok(*v == false)
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::io::ErrorKind;
+
+    use embedded_hal::digital::v2::{OutputPin, InputPin};
+    use TransactionKind::{Get, Set};
+
+    #[test]
+    fn test_input_pin() {
+        let expectations = [
+            Transaction::new(Get(true)),
+            Transaction::new(Get(true)),
+            Transaction::new(Get(false)),
+            Transaction::new(Get(false)),
+            Transaction::new(Get(true)).with_error(MockError::Io(ErrorKind::NotConnected)),
+        ];
+        let mut pin = Mock::new(&expectations);
+
+        assert_eq!(pin.is_high().unwrap(), true);
+        assert_eq!(pin.is_low().unwrap(), false);
+        assert_eq!(pin.is_high().unwrap(), false);
+        assert_eq!(pin.is_low().unwrap(), true);
+
+        pin.is_low().expect_err("expected error return");
+
+        pin.done();
+    }
+
+    #[test]
+    fn test_output_pin() {
+        let expectations = [
+            Transaction::new(Set(true)),
+            Transaction::new(Set(false)),
+            Transaction::new(Set(true)).with_error(MockError::Io(ErrorKind::NotConnected)),
+        ];
+        let mut pin = Mock::new(&expectations);
+
+        pin.set_high().unwrap();
+        pin.set_low().unwrap();
+        
+        pin.set_high().expect_err("expected error return");
+
+        pin.done();
+    }
+
+}

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,17 +1,17 @@
 //! Mock digital [`InputPin`] and [`OutputPin`] implementations
-//! 
+//!
 //! [`InputPin`]: https://docs.rs/embedded-hal/latest/embedded_hal/digital/trait.InputPin.html
 //! [`OutputPin`]: https://docs.rs/embedded-hal/latest/embedded_hal/digital/trait.OutputPin.html
-//! 
+//!
 //! ```
 //! use std::io::ErrorKind;
-//! 
+//!
 //! use embedded_hal_mock::MockError;
 //! use embedded_hal_mock::pin::{Transaction as PinTransaction, Mock as PinMock, State as PinState};
 //! use embedded_hal::digital::v2::{InputPin, OutputPin};
-//! 
+//!
 //! let err = MockError::Io(ErrorKind::NotConnected);
-//! 
+//!
 //! // Configure expectations
 //! let expectations = [
 //!     PinTransaction::get(PinState::High),
@@ -19,31 +19,30 @@
 //!     PinTransaction::set(PinState::Low),
 //!     PinTransaction::set(PinState::High).with_error(err.clone()),
 //! ];
-//! 
+//!
 //! // Create pin
 //! let mut pin = PinMock::new(&expectations);
-//! 
+//!
 //! // Run and test
 //! assert_eq!(pin.is_high().unwrap(), true);
 //! assert_eq!(pin.is_low().unwrap(), false);
-//! 
+//!
 //! pin.set_low().unwrap();
 //! pin.set_high().expect_err("expected error return");
-//! 
+//!
 //! pin.done();
-//! 
+//!
 //! // Update expectations
 //! pin.expect(&[]);
 //! // ...
 //! pin.done();
-//! 
+//!
 //! ```
-
 
 use crate::common::Generic;
 use crate::error::MockError;
 
-use embedded_hal::digital::v2::{OutputPin, InputPin};
+use embedded_hal::digital::v2::{InputPin, OutputPin};
 
 /// MockPin transaction
 #[derive(PartialEq, Clone, Debug)]
@@ -68,7 +67,7 @@ pub enum State {
 impl Transaction {
     /// Create a new pin transaction
     pub fn new(kind: TransactionKind) -> Transaction {
-        Transaction{kind, err: None}
+        Transaction { kind, err: None }
     }
 
     /// Create a new get transaction
@@ -118,10 +117,14 @@ impl OutputPin for Mock {
 
     /// Drives the pin low
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        let Transaction{kind, err} = self.next().expect("no expectation for pin::set_low call");
+        let Transaction { kind, err } = self.next().expect("no expectation for pin::set_low call");
 
-        assert_eq!(kind, TransactionKind::Set(State::Low), "expected pin::set_low");
-        
+        assert_eq!(
+            kind,
+            TransactionKind::Set(State::Low),
+            "expected pin::set_low"
+        );
+
         match err {
             Some(e) => Err(e.clone()),
             None => Ok(()),
@@ -130,10 +133,14 @@ impl OutputPin for Mock {
 
     /// Drives the pin high
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        let Transaction{kind, err} = self.next().expect("no expectation for pin::set_high call");
+        let Transaction { kind, err } = self.next().expect("no expectation for pin::set_high call");
 
-        assert_eq!(kind, TransactionKind::Set(State::High), "expected pin::set_high");
-        
+        assert_eq!(
+            kind,
+            TransactionKind::Set(State::High),
+            "expected pin::set_high"
+        );
+
         match err {
             Some(e) => Err(e.clone()),
             None => Ok(()),
@@ -149,11 +156,11 @@ impl InputPin for Mock {
     fn is_high(&self) -> Result<bool, Self::Error> {
         let mut s = self.clone();
 
-        let Transaction{kind, err} = s.next().expect("no expectation for pin::is_high call");
+        let Transaction { kind, err } = s.next().expect("no expectation for pin::is_high call");
 
         assert_eq!(kind.is_get(), true, "expected pin::get");
 
-        if let Some(e) = err { 
+        if let Some(e) = err {
             Err(e.clone())
         } else if let TransactionKind::Get(v) = kind {
             Ok(v == State::High)
@@ -166,11 +173,11 @@ impl InputPin for Mock {
     fn is_low(&self) -> Result<bool, Self::Error> {
         let mut s = self.clone();
 
-        let Transaction{kind, err} = s.next().expect("no expectation for pin::is_low call");
+        let Transaction { kind, err } = s.next().expect("no expectation for pin::is_low call");
 
         assert_eq!(kind.is_get(), true, "expected pin::get");
 
-        if let Some(e) = err { 
+        if let Some(e) = err {
             Err(e.clone())
         } else if let TransactionKind::Get(v) = kind {
             Ok(v == State::Low)
@@ -180,17 +187,16 @@ impl InputPin for Mock {
     }
 }
 
-
 #[cfg(test)]
 mod test {
 
     use std::io::ErrorKind;
 
-    use embedded_hal::digital::v2::{OutputPin, InputPin};
     use crate::error::MockError;
-    
-    use crate::pin::{Mock, Transaction, State};
+    use embedded_hal::digital::v2::{InputPin, OutputPin};
+
     use crate::pin::TransactionKind::{Get, Set};
+    use crate::pin::{Mock, State, Transaction};
 
     #[test]
     fn test_input_pin() {
@@ -224,7 +230,7 @@ mod test {
 
         pin.set_high().unwrap();
         pin.set_low().unwrap();
-        
+
         pin.set_high().expect_err("expected error return");
 
         pin.done();

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -183,12 +183,14 @@ impl InputPin for Mock {
 
 #[cfg(test)]
 mod test {
-    use super::*;
 
     use std::io::ErrorKind;
 
     use embedded_hal::digital::v2::{OutputPin, InputPin};
-    use TransactionKind::{Get, Set};
+    use crate::error::MockError;
+    
+    use crate::pin::{Mock, Transaction, State};
+    use crate::pin::TransactionKind::{Get, Set};
 
     #[test]
     fn test_input_pin() {


### PR DESCRIPTION
Mock pin implementation, this implements mocks for the digital::v2 traits and is thus blocked on an embedded-hal release including these.