### PR TITLE
Friendlier expectations

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -16,14 +16,16 @@ pub struct Generic<T: Clone + Debug + PartialEq> {
     expected: Arc<Mutex<(usize, Vec<T>)>>,
 }
 
-impl<'a, T: 'a> Generic<T> 
-where T: Clone + Debug + PartialEq,
+impl<'a, T: 'a> Generic<T>
+where
+    T: Clone + Debug + PartialEq,
 {
     /// Create a new mock interface
     ///
     /// This creates a new generic mock interface with initial expectations
-    pub fn new<E>(expected: E) -> Generic<T> 
-    where E: IntoIterator<Item=&'a T>
+    pub fn new<E>(expected: E) -> Generic<T>
+    where
+        E: IntoIterator<Item = &'a T>,
     {
         let mut g = Generic {
             expected: Arc::new(Mutex::new((0, vec![]))),
@@ -39,9 +41,10 @@ where T: Clone + Debug + PartialEq,
     /// This is a list of transactions to be executed in order
     /// Note that setting this will overwrite any existing expectations
     pub fn expect<E>(&mut self, expected: E)
-    where E: IntoIterator<Item=&'a T>
+    where
+        E: IntoIterator<Item = &'a T>,
     {
-        let v: Vec<T> = expected.into_iter().map(|v| v.clone() ).collect();
+        let v: Vec<T> = expected.into_iter().map(|v| v.clone()).collect();
         let mut e = self.expected.lock().unwrap();
         e.0 = 0;
         e.1 = v;
@@ -59,8 +62,9 @@ where T: Clone + Debug + PartialEq,
 }
 
 /// Clone allows a single mock to be duplicated for control and evaluation
-impl<T> Clone for Generic<T>  
-where T: Clone + Debug + PartialEq,
+impl<T> Clone for Generic<T>
+where
+    T: Clone + Debug + PartialEq,
 {
     fn clone(&self) -> Self {
         Generic {
@@ -70,14 +74,15 @@ where T: Clone + Debug + PartialEq,
 }
 
 /// Iterator impl for use in mock impls
-impl<T> Iterator for Generic<T>  
-where T: Clone + Debug + PartialEq,
+impl<T> Iterator for Generic<T>
+where
+    T: Clone + Debug + PartialEq,
 {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
         let mut e = self.expected.lock().unwrap();
         e.0 += 1;
-        e.1.get(e.0 - 1).map(|v| v.clone() )
+        e.1.get(e.0 - 1).map(|v| v.clone())
     }
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -92,9 +92,9 @@ impl Transaction {
 ///
 /// This supports the specification and evaluation of expectations to allow automated testing of I2C based drivers.
 /// Mismatches between expectations will cause runtime assertions to assist in locating the source of the fault.
-pub type Mock<'a> = Generic<'a, Transaction>;
+pub type Mock = Generic<Transaction>;
 
-impl<'a> i2c::Read for Mock<'a> {
+impl i2c::Read for Mock {
     type Error = MockError;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
@@ -116,7 +116,7 @@ impl<'a> i2c::Read for Mock<'a> {
     }
 }
 
-impl<'a> i2c::Write for Mock<'a> {
+impl i2c::Write for Mock {
     type Error = MockError;
 
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
@@ -135,7 +135,7 @@ impl<'a> i2c::Write for Mock<'a> {
     }
 }
 
-impl<'a> i2c::WriteRead for Mock<'a> {
+impl i2c::WriteRead for Mock {
     type Error = MockError;
 
     fn write_read(

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -118,9 +118,9 @@ impl Transaction {
 /// faults.
 ///
 /// See the usage section in the module level docs for an example.
-pub type Mock<'a> = Generic<'a, Transaction>;
+pub type Mock = Generic<Transaction>;
 
-impl<'a> spi::Write<u8> for Mock<'a> {
+impl spi::Write<u8> for Mock {
     type Error = MockError;
 
     /// spi::Write implementation for Mock
@@ -137,7 +137,7 @@ impl<'a> spi::Write<u8> for Mock<'a> {
     }
 }
 
-impl<'a> FullDuplex<u8> for Mock<'a> {
+impl FullDuplex<u8> for Mock {
     type Error = MockError;
     /// spi::FullDuplex implementeation for Mock
     ///
@@ -167,7 +167,7 @@ impl<'a> FullDuplex<u8> for Mock<'a> {
         Ok(buffer)
     }
 }
-impl<'a> spi::Transfer<u8> for Mock<'a> {
+impl spi::Transfer<u8> for Mock {
     type Error = MockError;
 
     /// spi::Transfer implementation for Mock
@@ -202,8 +202,7 @@ mod test {
 
     #[test]
     fn test_spi_mock_send() {
-        let expectations = [Transaction::send(10)];
-        let mut spi = Mock::new(&expectations);
+        let mut spi = Mock::new(vec![Transaction::send(10)]);
 
         let _ = spi.send(10).unwrap();
 
@@ -212,9 +211,7 @@ mod test {
 
     #[test]
     fn test_spi_mock_read() {
-        let expectations = [Transaction::read(10)];
-
-        let mut spi = Mock::new(&expectations);
+        let mut spi = Mock::new(vec![Transaction::read(10)]);
 
         let ans = spi.read().unwrap();
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -202,7 +202,7 @@ mod test {
 
     #[test]
     fn test_spi_mock_send() {
-        let mut spi = Mock::new(vec![Transaction::send(10)]);
+        let mut spi = Mock::new(&[Transaction::send(10)]);
 
         let _ = spi.send(10).unwrap();
 
@@ -211,7 +211,7 @@ mod test {
 
     #[test]
     fn test_spi_mock_read() {
-        let mut spi = Mock::new(vec![Transaction::read(10)]);
+        let mut spi = Mock::new(&[Transaction::read(10)]);
 
         let ans = spi.read().unwrap();
 


### PR DESCRIPTION
This PR alters the generic expectation module to accept `IntoIterator<Item=T>` types, allowing vector or slice references to be used with internal storage to avoid lifetime issues where expectations needed to outlive mock instances.