### PR TITLE
[WIP] top level mock wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = { version = "0.2.2", features = ["unproven"] }
+embedded-hal = { version = "0.2.3", features = ["unproven"] }
 nb = "0.1.1"
-
-[patch.crates-io]
-embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,9 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2"
+embedded-hal = { version = "0.2.2", features = ["unproven"] }
 nb = "0.1.1"
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal" }
+

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -117,6 +117,7 @@ impl Engine {
     }
 }
 
+#[derive(Clone)]
 pub struct Peripheral<Type> {
     id: u32,
     expected: Arc<Mutex<VecDeque<(u32, Transaction)>>>,
@@ -140,6 +141,7 @@ impl <Type>Peripheral<Type> {
 }
 
 /// Empty struct for type-state programming
+#[derive(Clone)]
 pub struct Spi {}
 
 impl Iterator for Peripheral<Spi>
@@ -166,6 +168,8 @@ impl Peripheral<Spi> {
 }
 
 /// Empty struct for type-state programming
+
+#[derive(Clone)]
 pub struct I2c {}
 
 impl Iterator for Peripheral<I2c>
@@ -193,8 +197,9 @@ impl Peripheral<I2c> {
 
 
 /// Empty struct for type-state programming
-pub struct Pin {}
 
+#[derive(Clone)]
+pub struct Pin {}
 impl Peripheral<Pin>
 {
     fn next(&self) -> Option<PinTransaction> {
@@ -286,6 +291,7 @@ impl InputPin for Peripheral<Pin> {
 }
 
 /// Empty struct for type-state programming
+#[derive(Clone)]
 pub struct Delay {}
 
 impl Iterator for Peripheral<Delay>
@@ -328,7 +334,7 @@ mod test {
     use std::io::ErrorKind;
 
     use embedded_hal::digital::v2::{OutputPin as _, InputPin as _};
-    use embedded_hal::blocking::spi::Write as _;
+    use embedded_hal::blocking::spi::{Write, Transfer};
     use embedded_hal::blocking::i2c::Write as _;
     use embedded_hal::blocking::delay::DelayMs as _;
 
@@ -340,6 +346,9 @@ mod test {
         let mut i2c1 = engine.i2c();
         let mut pin1 = engine.pin();
         let mut delay1 = engine.delay();
+
+        let mut _t: Box<Transfer<u8, Error=()>> = Box::new(spi1.clone());
+        let mut _w: Box<Write<u8, Error=()>> = Box::new(spi1.clone());
 
         pin1.expect(PinTransaction::set(PinState::High));
         spi1.inner().expect(SpiTransaction::write(vec![1, 2]));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,391 @@
+//! Mock Engine Implementation
+//! 
+//! This allows expectations to be created over multiple peripherals
+//! to support testing of more complex driver behaviors.
+//! 
+//! ```
+//! use embedded_hal::digital::v2::{OutputPin as _, InputPin as _};
+//! use embedded_hal::blocking::spi::Write as _;
+//! use embedded_hal::blocking::i2c::Write as _;
+//! use embedded_hal::blocking::delay::DelayMs as _;
+//! 
+//! use embedded_hal_mock::engine::*;
+//! 
+//! let mut engine = Engine::new();
+//! let mut spi1 = engine.spi();
+//! let mut spi2 = engine.spi();
+//! let mut i2c1 = engine.i2c();
+//! let mut pin1 = engine.pin();
+//! let mut delay1 = engine.delay();
+//!
+//! pin1.expect(PinTransaction::set(PinState::High));
+//! spi1.inner().expect(SpiTransaction::write(vec![1, 2]));
+//! spi2.inner().expect(SpiTransaction::write(vec![3, 4]));
+//! i2c1.inner().expect(I2cTransaction::write(0xaa, vec![5, 6]));
+//! delay1.expect(100);
+//!
+//! pin1.set_high();
+//! spi1.write(&vec![1, 2]);
+//! spi2.write(&vec![3, 4]);
+//! i2c1.write(0xaa, &vec![5, 6]);
+//! delay1.delay_ms(100);
+//!
+//! engine.done();
+//! ```
+//! 
+
+use std::sync::{Arc, Mutex};
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+use std::fmt::Debug;
+
+// Re-exports for user convenience
+pub use crate::spi::{Transaction as SpiTransaction, Mock as SpiMock};
+pub use crate::i2c::{Transaction as I2cTransaction, Mock as I2cMock};
+pub use crate::pin::{Transaction as PinTransaction, Mock as PinMock, State as PinState};
+
+// Unfortunately pin must be reimplemented due to &self InputPin methods
+use embedded_hal::digital::v2::{InputPin, OutputPin};
+use crate::pin::{TransactionKind as PinTransactionKind};
+use crate::error::MockError;
+
+/// Transactions supported by the engine
+#[derive(Debug, PartialEq, Clone)]
+pub enum Transaction {
+    /// Spi transactions
+    Spi(SpiTransaction),
+    /// I2c transactions
+    I2c(I2cTransaction),
+    /// Pin transactions
+    Pin(PinTransaction),
+    /// DelayMs transactions
+    DelayMs(u32),
+}
+
+pub struct Engine {
+    peripheral_count: u32,
+    expected: Arc<Mutex<VecDeque<(u32, Transaction)>>>,
+}
+
+impl Engine {
+
+    /// Create a new engine instance with no expectations loaded
+    pub fn new() -> Self {
+        Engine{peripheral_count: 0, expected: Arc::new(Mutex::new(VecDeque::new()))}
+    }
+
+    /// Create an SPI peripheral
+    pub fn spi(&mut self) -> SpiMock<Peripheral<Spi>> {
+        let p = Peripheral::new(self.peripheral_count, self.expected.clone());
+        self.peripheral_count += 1;
+        p.into()
+    }
+
+    /// Create an I2C peripheral
+    pub fn i2c(&mut self) -> I2cMock<Peripheral<I2c>> {
+        let p = Peripheral::new(self.peripheral_count, self.expected.clone());
+        self.peripheral_count += 1;
+        p.into()
+    }
+
+    /// Create a new Pin
+    pub fn pin(&mut self) -> Peripheral<Pin> {
+        let p = Peripheral::new(self.peripheral_count, self.expected.clone());
+        self.peripheral_count += 1;
+        p
+    }
+
+    /// Create a new Delay
+    pub fn delay(&mut self) -> Peripheral<Delay> {
+        let p = Peripheral::new(self.peripheral_count, self.expected.clone());
+        self.peripheral_count += 1;
+        p
+    }
+
+    /// Push an expectation to the internal buffer
+    /// This provides an alternative mechanism to peripheral.expect();
+    pub fn expect<T>(&mut self, p: &Peripheral<T>, t: Transaction) {
+        let mut expected = self.expected.lock().unwrap();
+        expected.push_back((p.id, t));
+    }
+
+    /// Finalize expectations
+    /// This checks for any remaining expectations and drains the internal buffer
+    pub fn done(&mut self) {
+        let remaining: Vec<_> = self.expected.lock().unwrap().drain(..).collect();
+        assert_eq!(remaining, vec![]);
+    }
+}
+
+pub struct Peripheral<Type> {
+    id: u32,
+    expected: Arc<Mutex<VecDeque<(u32, Transaction)>>>,
+    _type: PhantomData<Type>,
+}
+
+impl <Type>Peripheral<Type> {
+    fn new(id: u32, expected: Arc<Mutex<VecDeque<(u32, Transaction)>>>) -> Self {
+        Self{id, expected, _type: PhantomData }
+    }
+
+    fn pop_front(&mut self) -> Option<(u32, Transaction)> {
+        let mut e = self.expected.lock().unwrap();
+        e.pop_front()
+    }
+
+    fn push_back(&mut self, t: Transaction) {
+        let mut e = self.expected.lock().unwrap();
+        e.push_back((self.id, t));
+    }
+}
+
+/// Empty struct for type-state programming
+pub struct Spi {}
+
+impl Iterator for Peripheral<Spi>
+{
+    type Item = SpiTransaction;
+    fn next(&mut self) -> Option<Self::Item> {
+        let (id, transaction) = self.pop_front().expect("no transaction found");
+        assert_eq!(id, self.id);
+
+        match transaction {
+            Transaction::Spi(t) => Some(t),
+            _ => {
+                assert!(true, "expected SPI transaction, found: {:?}", transaction);
+                None
+            },
+        }     
+    }
+}
+
+impl Peripheral<Spi> {
+    pub fn expect(&mut self, t: SpiTransaction) {
+        self.push_back(Transaction::Spi(t))
+    }
+}
+
+/// Empty struct for type-state programming
+pub struct I2c {}
+
+impl Iterator for Peripheral<I2c>
+{
+    type Item = I2cTransaction;
+    fn next(&mut self) -> Option<Self::Item> {
+        let (id, transaction) = self.pop_front().expect("no transaction found");
+        assert_eq!(id, self.id);
+
+        match transaction {
+            Transaction::I2c(t) => Some(t),
+            _ => {
+                assert!(true, "expected I2C transaction, found: {:?}", transaction);
+                None
+            },
+        }     
+    }
+}
+
+impl Peripheral<I2c> {
+    pub fn expect(&mut self, t: I2cTransaction) {
+        self.push_back(Transaction::I2c(t))
+    }
+}
+
+
+/// Empty struct for type-state programming
+pub struct Pin {}
+
+impl Peripheral<Pin>
+{
+    fn next(&self) -> Option<PinTransaction> {
+        let mut e = self.expected.lock().unwrap();
+        let (id, transaction) = e.pop_front().expect("no transaction found");
+        assert_eq!(id, self.id);
+
+        match transaction {
+            Transaction::Pin(t) => Some(t),
+            _ => {
+                assert!(true, "expected Pin transaction, found: {:?}", transaction);
+                None
+            },
+        }
+    }
+
+    pub fn expect(&mut self, t: PinTransaction) {
+        self.push_back(Transaction::Pin(t))
+    }
+}
+
+/// Single digital push-pull output pin
+impl OutputPin for Peripheral<Pin> {
+    /// Error type
+    type Error = MockError;
+
+    /// Drives the pin low
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        let PinTransaction{kind, err} = self.next().expect("no expectation for pin::set_low call");
+
+        assert_eq!(kind, PinTransactionKind::Set(PinState::Low), "expected pin::set_low");
+        
+        match err {
+            Some(e) => Err(e.clone()),
+            None => Ok(()),
+        }
+    }
+
+    /// Drives the pin high
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        let PinTransaction{kind, err} = self.next().expect("no expectation for pin::set_high call");
+
+        assert_eq!(kind, PinTransactionKind::Set(PinState::High), "expected pin::set_high");
+        
+        match err {
+            Some(e) => Err(e.clone()),
+            None => Ok(()),
+        }
+    }
+}
+
+impl InputPin for Peripheral<Pin> {
+    /// Error type
+    type Error = MockError;
+
+    /// Is the input pin high?
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        let mut s = self.clone();
+
+        let PinTransaction{kind, err} = s.next().expect("no expectation for pin::is_high call");
+
+        assert_eq!(kind.is_get(), true, "expected pin::get");
+
+        if let Some(e) = err { 
+            Err(e.clone())
+        } else if let PinTransactionKind::Get(v) = kind {
+            Ok(v == PinState::High)
+        } else {
+            unreachable!();
+        }
+    }
+
+    /// Is the input pin low?
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        let mut s = self.clone();
+
+        let PinTransaction{kind, err} = s.next().expect("no expectation for pin::is_low call");
+
+        assert_eq!(kind.is_get(), true, "expected pin::get");
+
+        if let Some(e) = err { 
+            Err(e.clone())
+        } else if let PinTransactionKind::Get(v) = kind {
+            Ok(v == PinState::Low)
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+/// Empty struct for type-state programming
+pub struct Delay {}
+
+impl Iterator for Peripheral<Delay>
+{
+    type Item = u32;
+    fn next(&mut self) -> Option<Self::Item> {
+        let (id, transaction) = self.pop_front().expect("no transaction found");
+        assert_eq!(id, self.id);
+
+        match transaction {
+            Transaction::DelayMs(t) => Some(t),
+            _ => {
+                assert!(true, "expected Delay transaction, found: {:?}", transaction);
+                None
+            },
+        }     
+    }
+}
+
+impl Peripheral<Delay> {
+    pub fn expect(&mut self, t: u32) {
+        self.push_back(Transaction::DelayMs(t))
+    }
+}
+
+use embedded_hal::blocking::delay;
+
+impl delay::DelayMs<u32> for Peripheral<Delay> {
+    fn delay_ms(&mut self, v: u32) {
+        let e = self.next().unwrap();
+        assert_eq!(v, e);
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::io::ErrorKind;
+
+    use embedded_hal::digital::v2::{OutputPin as _, InputPin as _};
+    use embedded_hal::blocking::spi::Write as _;
+    use embedded_hal::blocking::i2c::Write as _;
+    use embedded_hal::blocking::delay::DelayMs as _;
+
+    #[test]
+    fn test_engine() {
+        let mut engine = Engine::new();
+        let mut spi1 = engine.spi();
+        let mut spi2 = engine.spi();
+        let mut i2c1 = engine.i2c();
+        let mut pin1 = engine.pin();
+        let mut delay1 = engine.delay();
+
+        pin1.expect(PinTransaction::set(PinState::High));
+        spi1.inner().expect(SpiTransaction::write(vec![1, 2]));
+        spi2.inner().expect(SpiTransaction::write(vec![3, 4]));
+        i2c1.inner().expect(I2cTransaction::write(0xaa, vec![5, 6]));
+        delay1.expect(100);
+
+        pin1.set_high();
+        spi1.write(&vec![1, 2]);
+        spi2.write(&vec![3, 4]);
+        i2c1.write(0xaa, &vec![5, 6]);
+        delay1.delay_ms(100);
+
+        engine.done();
+    }
+
+    #[test]
+    #[should_panic]
+    fn wrong_peripheral_type() {
+        let mut engine = Engine::new();
+        let mut spi1 = engine.spi();
+        let mut i2c1 = engine.i2c();
+
+        spi1.inner().expect(SpiTransaction::write(vec![1, 2]));
+        i2c1.inner().expect(I2cTransaction::write(0xaa, vec![5, 6]));
+
+        i2c1.write(0xaa, &vec![5, 6]);
+        spi1.write(&vec![1, 2]);
+
+        engine.done();
+    }
+
+    #[test]
+    #[should_panic]
+    fn wrong_peripheral_id() {
+        let mut engine = Engine::new();
+        let mut spi1 = engine.spi();
+        let mut spi2 = engine.spi();
+
+
+        spi1.inner().expect(SpiTransaction::write(vec![1, 2]));
+        spi2.inner().expect(SpiTransaction::write(vec![3, 4]));
+
+        spi2.write(&vec![3, 4]);
+        spi1.write(&vec![1, 2]);
+
+        engine.done();
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,14 @@
 use std::io;
 
 /// Errors that may occur during mocking.
-#[derive(Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum MockError {
     /// An I/O-Error occurred
-    Io(io::Error),
+    Io(io::ErrorKind),
 }
 
 impl From<io::Error> for MockError {
     fn from(e: io::Error) -> Self {
-        MockError::Io(e)
+        MockError::Io(e.kind())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,4 @@ pub mod common;
 pub mod delay;
 pub mod i2c;
 pub mod spi;
+pub mod pin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! Currently this crate is not `no_std`. If you think this is important, let
 //! me know.
 
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 
 mod error;
 pub use crate::error::MockError;
@@ -25,3 +25,5 @@ pub mod delay;
 pub mod i2c;
 pub mod spi;
 pub mod pin;
+
+pub mod engine;

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -49,11 +49,11 @@ use embedded_hal::digital::v2::{OutputPin, InputPin};
 #[derive(PartialEq, Clone, Debug)]
 pub struct Transaction {
     /// Kind is the transaction kind (and data) expected
-    kind: TransactionKind,
+    pub(crate) kind: TransactionKind,
     /// Err is an optional error return for a transaction.
     /// This is in addition to kind to allow validation that the transaction kind
     /// is correct prior to returning the error.
-    err: Option<MockError>,
+    pub(crate) err: Option<MockError>,
 }
 
 #[derive(PartialEq, Clone, Debug)]
@@ -100,7 +100,7 @@ pub enum TransactionKind {
 }
 
 impl TransactionKind {
-    fn is_get(&self) -> bool {
+    pub(crate) fn is_get(&self) -> bool {
         match self {
             TransactionKind::Get(_) => true,
             _ => false,

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -97,10 +97,10 @@ impl TransactionKind {
 }
 
 /// Mock Pin implementation
-pub type Mock<'a> = Generic<'a, Transaction>;
+pub type Mock = Generic<Transaction>;
 
 /// Single digital push-pull output pin
-impl <'a>OutputPin for Mock<'a> {
+impl OutputPin for Mock {
     /// Error type
     type Error = MockError;
 
@@ -108,7 +108,7 @@ impl <'a>OutputPin for Mock<'a> {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         let Transaction{kind, err} = self.next().expect("no expectation for pin::set_low call");
 
-        assert_eq!(*kind, TransactionKind::Set(false), "expected pin::set_low");
+        assert_eq!(kind, TransactionKind::Set(false), "expected pin::set_low");
         
         match err {
             Some(e) => Err(e.clone()),
@@ -120,7 +120,7 @@ impl <'a>OutputPin for Mock<'a> {
     fn set_high(&mut self) -> Result<(), Self::Error> {
         let Transaction{kind, err} = self.next().expect("no expectation for pin::set_high call");
 
-        assert_eq!(*kind, TransactionKind::Set(true), "expected pin::set_high");
+        assert_eq!(kind, TransactionKind::Set(true), "expected pin::set_high");
         
         match err {
             Some(e) => Err(e.clone()),
@@ -129,7 +129,7 @@ impl <'a>OutputPin for Mock<'a> {
     }
 }
 
-impl <'a>InputPin for Mock<'a> {
+impl InputPin for Mock {
     /// Error type
     type Error = MockError;
 
@@ -144,7 +144,7 @@ impl <'a>InputPin for Mock<'a> {
         if let Some(e) = err { 
             Err(e.clone())
         } else if let TransactionKind::Get(v) = kind {
-            Ok(*v == true)
+            Ok(v == true)
         } else {
             unreachable!();
         }
@@ -161,7 +161,7 @@ impl <'a>InputPin for Mock<'a> {
         if let Some(e) = err { 
             Err(e.clone())
         } else if let TransactionKind::Get(v) = kind {
-            Ok(*v == false)
+            Ok(v == false)
         } else {
             unreachable!();
         }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,0 +1,219 @@
+//! Mock digital InputPin and OutputPin implementations
+//! 
+//! ```
+//! use std::io::ErrorKind;
+//! 
+//! use embedded_hal_mock::MockError;
+//! use embedded_hal_mock::pin::{Transaction as PinTransaction, Mock as MockPin};
+//! use embedded_hal::digital::v2::{InputPin, OutputPin};
+//! 
+//! let err = MockError::Io(ErrorKind::NotConnected);
+//! 
+//! // Configure expectations
+//! let expectations = [
+//!     PinTransaction::get(true),
+//!     PinTransaction::get(true),
+//!     PinTransaction::set(false),
+//!     PinTransaction::set(true).with_error(err.clone()),
+//! ];
+//! 
+//! // Create pin
+//! let mut pin = MockPin::new(&expectations);
+//! 
+//! // Run and test
+//! assert_eq!(pin.is_high().unwrap(), true);
+//! assert_eq!(pin.is_low().unwrap(), false);
+//! 
+//! pin.set_low().unwrap();
+//! pin.set_high().expect_err("expected error return");
+//! 
+//! pin.done();
+//! 
+//! // Update expectations
+//! pin.expect(&[]);
+//! // ...
+//! pin.done();
+//! 
+//! ```
+
+
+use crate::common::Generic;
+use crate::error::MockError;
+
+use embedded_hal::digital::v2::{OutputPin, InputPin};
+
+/// MockPin transaction
+#[derive(PartialEq, Clone, Debug)]
+pub struct Transaction {
+    /// Kind is the transaction kind (and data) expected
+    kind: TransactionKind,
+    /// Err is an optional error return for a transaction.
+    /// This is in addition to kind to allow validation that the transaction kind
+    /// is correct prior to returning the error.
+    err: Option<MockError>,
+}
+
+impl Transaction {
+    /// Create a new pin transaction
+    pub fn new(kind: TransactionKind) -> Transaction {
+        Transaction{kind, err: None}
+    }
+
+    /// Create a new get transaction
+    pub fn get(value: bool) -> Transaction {
+        Transaction::new(TransactionKind::Get(value))
+    }
+
+    /// Create a new get transaction
+    pub fn set(value: bool) -> Transaction {
+        Transaction::new(TransactionKind::Set(value))
+    }
+
+    /// Add an error return to a transaction
+    /// This is used to mock failure behaviours
+    pub fn with_error(self, error: MockError) -> Self {
+        let mut t = self;
+        t.err = Some(error);
+        t
+    }
+}
+
+/// MockPin transaction kind, either Get or Set a bool
+#[derive(PartialEq, Clone, Debug)]
+pub enum TransactionKind {
+    /// Set(true) for set_high or Set(false) for set_low
+    Set(bool),
+    /// Get(true) for high value or Get(false) for low value
+    Get(bool),
+}
+
+impl TransactionKind {
+    fn is_get(&self) -> bool {
+        match self {
+            TransactionKind::Get(_) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Mock Pin implementation
+pub type Mock<'a> = Generic<'a, Transaction>;
+
+/// Single digital push-pull output pin
+impl <'a>OutputPin for Mock<'a> {
+    /// Error type
+    type Error = MockError;
+
+    /// Drives the pin low
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        let Transaction{kind, err} = self.next().expect("no expectation for pin::set_low call");
+
+        assert_eq!(*kind, TransactionKind::Set(false), "expected pin::set_low");
+        
+        match err {
+            Some(e) => Err(e.clone()),
+            None => Ok(()),
+        }
+    }
+
+    /// Drives the pin high
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        let Transaction{kind, err} = self.next().expect("no expectation for pin::set_high call");
+
+        assert_eq!(*kind, TransactionKind::Set(true), "expected pin::set_high");
+        
+        match err {
+            Some(e) => Err(e.clone()),
+            None => Ok(()),
+        }
+    }
+}
+
+impl <'a>InputPin for Mock<'a> {
+    /// Error type
+    type Error = MockError;
+
+    /// Is the input pin high?
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        let mut s = self.clone();
+
+        let Transaction{kind, err} = s.next().expect("no expectation for pin::is_high call");
+
+        assert_eq!(kind.is_get(), true, "expected pin::get");
+
+        if let Some(e) = err { 
+            Err(e.clone())
+        } else if let TransactionKind::Get(v) = kind {
+            Ok(*v == true)
+        } else {
+            unreachable!();
+        }
+    }
+
+    /// Is the input pin low?
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        let mut s = self.clone();
+
+        let Transaction{kind, err} = s.next().expect("no expectation for pin::is_low call");
+
+        assert_eq!(kind.is_get(), true, "expected pin::get");
+
+        if let Some(e) = err { 
+            Err(e.clone())
+        } else if let TransactionKind::Get(v) = kind {
+            Ok(*v == false)
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::io::ErrorKind;
+
+    use embedded_hal::digital::v2::{OutputPin, InputPin};
+    use TransactionKind::{Get, Set};
+
+    #[test]
+    fn test_input_pin() {
+        let expectations = [
+            Transaction::new(Get(true)),
+            Transaction::new(Get(true)),
+            Transaction::new(Get(false)),
+            Transaction::new(Get(false)),
+            Transaction::new(Get(true)).with_error(MockError::Io(ErrorKind::NotConnected)),
+        ];
+        let mut pin = Mock::new(&expectations);
+
+        assert_eq!(pin.is_high().unwrap(), true);
+        assert_eq!(pin.is_low().unwrap(), false);
+        assert_eq!(pin.is_high().unwrap(), false);
+        assert_eq!(pin.is_low().unwrap(), true);
+
+        pin.is_low().expect_err("expected error return");
+
+        pin.done();
+    }
+
+    #[test]
+    fn test_output_pin() {
+        let expectations = [
+            Transaction::new(Set(true)),
+            Transaction::new(Set(false)),
+            Transaction::new(Set(true)).with_error(MockError::Io(ErrorKind::NotConnected)),
+        ];
+        let mut pin = Mock::new(&expectations);
+
+        pin.set_high().unwrap();
+        pin.set_low().unwrap();
+        
+        pin.set_high().expect_err("expected error return");
+
+        pin.done();
+    }
+
+}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -119,12 +119,12 @@ impl Transaction {
 ///
 /// See the usage section in the module level docs for an example.
 #[derive(Clone)]
-pub struct Mock<T: Iterator<Item=Transaction>> {
+pub struct Mock<T: Iterator<Item=Transaction> + Clone> {
     iter: T,
 }
 
 impl <T> Mock<T> 
-where T: Iterator<Item=Transaction>,
+where T: Iterator<Item=Transaction> + Clone,
 {
     pub fn done(&mut self) {
         let next = self.iter.next();
@@ -146,7 +146,7 @@ impl <'a> Mock<Generic<Transaction>> {
 }
 
 impl <T> From<T> for Mock<T> 
-where T: Iterator<Item=Transaction>,
+where T: Iterator<Item=Transaction> + Clone,
 {
     fn from(iter: T) -> Self {
         Self{iter}
@@ -154,9 +154,9 @@ where T: Iterator<Item=Transaction>,
 }
 
 impl <T> spi::Write<u8> for Mock<T> 
-where T: Iterator<Item=Transaction>,
+where T: Iterator<Item=Transaction> + Clone,
 {
-    type Error = MockError;
+    type Error = ();
 
     /// spi::Write implementation for Mock
     ///
@@ -173,9 +173,9 @@ where T: Iterator<Item=Transaction>,
 }
 
 impl <T> FullDuplex<u8> for Mock <T> 
-where T: Iterator<Item=Transaction>,
+where T: Iterator<Item=Transaction> + Clone,
 {
-    type Error = MockError;
+    type Error = ();
     /// spi::FullDuplex implementeation for Mock
     ///
     /// This will call the nonblocking read/write primitives.
@@ -206,9 +206,9 @@ where T: Iterator<Item=Transaction>,
 }
 
 impl <T> spi::Transfer<u8> for Mock<T>
-where T: Iterator<Item=Transaction>,
+where T: Iterator<Item=Transaction> + Clone,
 {
-    type Error = MockError;
+    type Error = ();
 
     /// spi::Transfer implementation for Mock
     ///
@@ -239,6 +239,16 @@ mod test {
     use super::*;
 
     use embedded_hal::blocking::spi::{Transfer, Write};
+
+    #[test]
+    fn test_spi_mock_cast() {
+        let mut spi = Mock::new(&[]);
+
+        let mut _t: Box<Transfer<u8, Error=()>> = Box::new(spi.clone());
+        let mut _w: Box<Write<u8, Error=()>> = Box::new(spi.clone());
+
+        spi.done();
+    }
 
     #[test]
     fn test_spi_mock_send() {


### PR DESCRIPTION
a rough attempt at a higher level mocking interface that allows multiple peripherals to be tested together (see: #19).

to achieve this i re-factored the spi and i2c modules over a generic iterator, however the pin object is incompatible with this approach :-/

this depends on #18 