### PR TITLE
Improve serial transaction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## 0.7.0 - unreleased
+
+### Added
+
+- The serial transaction API now has two new constructor methods: `read_many`
+  and `write_many`.
+
+### Changed
+
+- The serial transaction API changed: The `Transaction::write` function now
+  expects a single word, not a collection of words. To add a transaction for
+  many writes, use `Transaction::write_many` instead.
+
+
 ## 0.6.0 - 2019-05-10
 
 ### Added


### PR DESCRIPTION
Make the serial transaction API more consistent.

Previous API:

```rust
fn read(expected: Word) -> Transaction;
fn write<Ws>(words: Ws) -> Transaction where Ws: AsRef<[Word]>;
```

New API:

```rust
fn read(word: Word) -> Transaction;
fn read_many<Ws>(words: Ws) -> Transaction where Ws: AsRef<[Word]>;
fn write(word: Word) -> Transaction;
fn write_many<Ws>(words: Ws) -> Transaction where Ws: AsRef<[Word]>;
```

This is a breaking change, but should result in a more consistent API to create transactions. It also has the side effect that both `read_many` and `write_many` accept byte slices like `b"hello"`.

CC @mciantyre 