### PR TITLE
i2c: Implement error expectations

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -28,6 +28,15 @@
 //! // Finalise expectations
 //! i2c.done();
 //! ```
+//!
+//! ## Transactions
+//!
+//! There are currently three transaction types:
+//!
+//! - `Read`: This expects an I²C `read` command and will return the wrapped bytes.
+//! - `Write`: This expects an I²C `write` command with the wrapped bytes.
+//! - `WriteRead`: This expects an I²C `write_read` command where the
+//!   `expected` bytes are written and the `response` bytes are returned.
 
 use embedded_hal::blocking::i2c;
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -37,6 +37,39 @@
 //! - `Write`: This expects an I²C `write` command with the wrapped bytes.
 //! - `WriteRead`: This expects an I²C `write_read` command where the
 //!   `expected` bytes are written and the `response` bytes are returned.
+//!
+//! ## Testing Error Handling
+//!
+//! If you want to test error handling of your code, you can attach an error to
+//! a transaction. When the transaction is executed, an error is returned.
+//!
+//! ```
+//! # extern crate embedded_hal;
+//! # extern crate embedded_hal_mock;
+//! # use embedded_hal::prelude::*;
+//! # use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
+//! # use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTransaction};
+//! use std::io::ErrorKind;
+//! use embedded_hal_mock::MockError;
+//!
+//! // Configure expectations
+//! let expectations = [
+//!     I2cTransaction::write(0xaa, vec![1, 2]),
+//!     I2cTransaction::read(0xbb, vec![3, 4]).with_error(MockError::Io(ErrorKind::Other)),
+//! ];
+//! let mut i2c = I2cMock::new(&expectations);
+//!
+//! // Writing returns without an error
+//! i2c.write(0xaa, &vec![1, 2]).unwrap();
+//!
+//! // Reading returns an error
+//! let mut buf = vec![0u8; 2];
+//! let err = i2c.read(0xbb, &mut buf).unwrap_err();
+//! assert_eq!(err, MockError::Io(ErrorKind::Other));
+//!
+//! // Finalise expectations
+//! i2c.done();
+//! ```
 
 use embedded_hal::blocking::i2c;
 
@@ -63,6 +96,11 @@ pub struct Transaction {
     expected_addr: u8,
     expected_data: Vec<u8>,
     response_data: Vec<u8>,
+    /// An optional error return for a transaction.
+    ///
+    /// This is in addition to the mode to allow validation that the
+    /// transaction mode is correct prior to returning the error.
+    expected_err: Option<MockError>,
 }
 
 impl Transaction {
@@ -73,6 +111,7 @@ impl Transaction {
             expected_addr: addr,
             expected_data: expected,
             response_data: Vec::new(),
+            expected_err: None,
         }
     }
 
@@ -83,6 +122,7 @@ impl Transaction {
             expected_addr: addr,
             expected_data: Vec::new(),
             response_data: response,
+            expected_err: None,
         }
     }
 
@@ -93,7 +133,16 @@ impl Transaction {
             expected_addr: addr,
             expected_data: expected,
             response_data: response,
+            expected_err: None,
         }
+    }
+
+    /// Add an error return to a transaction
+    ///
+    /// This is used to mock failure behaviours.
+    pub fn with_error(mut self, error: MockError) -> Self {
+        self.expected_err = Some(error);
+        self
     }
 }
 
@@ -119,9 +168,14 @@ impl i2c::Read for Mock {
             w.response_data.len(),
             "i2c:read mismatched response length"
         );
-        buffer.copy_from_slice(&w.response_data);
 
-        Ok(())
+        match w.expected_err {
+            Some(err) => Err(err),
+            None => {
+                buffer.copy_from_slice(&w.response_data);
+                Ok(())
+            }
+        }
     }
 }
 
@@ -140,7 +194,10 @@ impl i2c::Write for Mock {
             "i2c::write data does not match expectation"
         );
 
-        Ok(())
+        match w.expected_err {
+            Some(err) => Err(err),
+            None => Ok(()),
+        }
     }
 }
 
@@ -173,15 +230,22 @@ impl i2c::WriteRead for Mock {
             w.response_data.len(),
             "i2c::write_read mismatched response length"
         );
-        buffer.copy_from_slice(&w.response_data);
 
-        Ok(())
+        match w.expected_err {
+            Some(err) => Err(err),
+            None => {
+                buffer.copy_from_slice(&w.response_data);
+                Ok(())
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use std::io::ErrorKind as IoErrorKind;
 
     use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 
@@ -322,5 +386,92 @@ mod test {
         let i2c = Mock::new(&expectations);
         let mut i2c_clone = i2c.clone();
         i2c_clone.done();
+    }
+
+    mod expect_errors {
+        use super::*;
+
+        #[test]
+        fn write() {
+            let expected_err = MockError::Io(IoErrorKind::Other);
+            let mut i2c = Mock::new(&[
+                Transaction::write(0xaa, vec![10, 12]).with_error(expected_err.clone())
+            ]);
+            let err = i2c.write(0xaa, &vec![10, 12]).unwrap_err();
+            assert_eq!(err, expected_err);
+            i2c.done();
+        }
+
+        /// The transaction mode should still be validated.
+        #[test]
+        #[should_panic]
+        fn write_wrong_mode() {
+            let mut i2c = Mock::new(&[Transaction::write(0xaa, vec![10, 12])
+                .with_error(MockError::Io(IoErrorKind::Other))]);
+            let mut buf = vec![0u8; 2];
+            let _ = i2c.read(0xaa, &mut buf);
+        }
+
+        /// The transaction bytes should still be validated.
+        #[test]
+        #[should_panic]
+        fn write_wrong_data() {
+            let mut i2c = Mock::new(&[Transaction::write(0xaa, vec![10, 12])
+                .with_error(MockError::Io(IoErrorKind::Other))]);
+            let _ = i2c.write(0xaa, &vec![10, 13]);
+        }
+
+        #[test]
+        fn read() {
+            let expected_err = MockError::Io(IoErrorKind::Other);
+            let mut i2c =
+                Mock::new(
+                    &[Transaction::read(0xaa, vec![10, 12]).with_error(expected_err.clone())],
+                );
+            let mut buf = vec![0u8; 2];
+            let err = i2c.read(0xaa, &mut buf).unwrap_err();
+            assert_eq!(err, expected_err);
+            i2c.done();
+        }
+
+        /// The transaction mode should still be validated.
+        #[test]
+        #[should_panic]
+        fn read_wrong_mode() {
+            let mut i2c =
+                Mock::new(&[Transaction::read(0xaa, vec![10, 12])
+                    .with_error(MockError::Io(IoErrorKind::Other))]);
+            let _ = i2c.write(0xaa, &vec![10, 12]);
+        }
+
+        #[test]
+        fn write_read() {
+            let expected_err = MockError::Io(IoErrorKind::Other);
+            let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
+                .with_error(expected_err.clone())]);
+            let mut buf = vec![0u8; 2];
+            let err = i2c.write_read(0xaa, &[10, 12], &mut buf).unwrap_err();
+            assert_eq!(err, expected_err);
+            i2c.done();
+        }
+
+        /// The transaction mode should still be validated.
+        #[test]
+        #[should_panic]
+        fn write_read_wrong_mode() {
+            let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
+                .with_error(MockError::Io(IoErrorKind::Other))]);
+            let _ = i2c.write(0xaa, &vec![10, 12]);
+        }
+
+        /// The transaction bytes should still be validated.
+        #[test]
+        #[should_panic]
+        fn write_read_wrong_data() {
+            let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
+                .with_error(MockError::Io(IoErrorKind::Other))]);
+            let mut buf = vec![0u8; 2];
+            let _ = i2c.write_read(0xaa, &vec![10, 13], &mut buf);
+        }
     }
 }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -81,11 +81,11 @@ impl Transaction {
     }
 
     /// Add an error return to a transaction
-    /// This is used to mock failure behaviours
-    pub fn with_error(self, error: MockError) -> Self {
-        let mut t = self;
-        t.err = Some(error);
-        t
+    ///
+    /// This is used to mock failure behaviours.
+    pub fn with_error(mut self, error: MockError) -> Self {
+        self.err = Some(error);
+        self
     }
 }
 
@@ -235,5 +235,4 @@ mod test {
 
         pin.done();
     }
-
 }


### PR DESCRIPTION
Allow expecting I²C errors, similar to how it was implemented by @ryankurte for the Pin mocks.

Tests and documentation are updated as well.

Fixes #9.