### PR TITLE
I2c write iter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
+embedded-hal = { version = "0.2.7", features = ["unproven"] }
 nb = "0.1.1"

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -244,6 +244,39 @@ impl i2c::WriteRead for Mock {
     }
 }
 
+impl i2c::WriteIterRead for Mock {
+    type Error = MockError;
+
+    fn write_iter_read<B>(
+        &mut self,
+        address: u8,
+        bytes: B,
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error>
+    where
+        B: IntoIterator<Item = u8>,
+    {
+        // Just collect the bytes and pass them on to the WriteRead::write_read implementation
+        use i2c::WriteRead;
+        let bytes: Vec<_> = bytes.into_iter().collect();
+        self.write_read(address, bytes.as_slice(), buffer)
+    }
+}
+
+impl i2c::WriteIter for Mock {
+    type Error = MockError;
+
+    fn write<B>(&mut self, address: u8, bytes: B) -> Result<(), Self::Error>
+    where
+        B: IntoIterator<Item = u8>,
+    {
+        // Just collect the bytes and pass them on to the Write::write implementation
+        use i2c::Write;
+        let bytes: Vec<_> = bytes.into_iter().collect();
+        Write::write(self, address, bytes.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -257,7 +257,7 @@ impl i2c::WriteIterRead for Mock {
         B: IntoIterator<Item = u8>,
     {
         // Just collect the bytes and pass them on to the WriteRead::write_read implementation
-        use i2c::WriteRead;
+        use embedded_hal::blocking::i2c::WriteRead;
         let bytes: Vec<_> = bytes.into_iter().collect();
         self.write_read(address, bytes.as_slice(), buffer)
     }
@@ -271,7 +271,7 @@ impl i2c::WriteIter for Mock {
         B: IntoIterator<Item = u8>,
     {
         // Just collect the bytes and pass them on to the Write::write implementation
-        use i2c::Write;
+        use embedded_hal::blocking::i2c::Write;
         let bytes: Vec<_> = bytes.into_iter().collect();
         Write::write(self, address, bytes.as_slice())
     }


### PR DESCRIPTION
Implement WriteIter and WriteIterRead for i2c mock and bumb embedded-hal version.