### PR TITLE
spi: add Transaction::read_vec

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -127,6 +127,15 @@ impl Transaction {
         }
     }
 
+    /// Create a read transaction
+    pub fn read_vec(response: Vec<u8>) -> Transaction {
+        Transaction {
+            expected_mode: Mode::Read,
+            expected_data: Vec::new(),
+            response,
+        }
+    }
+
     /// Create flush transaction
     pub fn flush() -> Transaction {
         Transaction {


### PR DESCRIPTION
At the moment SPI reads with a length >1 cannot be represented.