### PR TITLE
nb: use embedded-hal re-export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,3 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "=1.0.0-alpha.8"
-nb = "0.1.1"

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -94,6 +94,7 @@
 //! #     Mock as SerialMock,
 //! #     Transaction as SerialTransaction,
 //! # };
+//! use embedded_hal::nb;
 //! use embedded_hal::serial::nb::{Read, Write};
 //! use embedded_hal::serial::ErrorKind;
 //!
@@ -142,6 +143,7 @@
 // make the public API any more confusing for users, and it permits
 // maximal flexibility.
 
+use embedded_hal::nb;
 use embedded_hal::serial::nb as serial;
 use embedded_hal::serial::ErrorKind;
 use embedded_hal::serial::ErrorType;
@@ -444,7 +446,7 @@ mod test {
     use embedded_hal::serial::nb::{Read, Write};
     use embedded_hal::serial::ErrorKind;
 
-    use super::{Mock, Transaction};
+    use super::{nb, Mock, Transaction};
 
     #[test]
     fn test_serial_mock_read() {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -43,12 +43,12 @@
 //! // Finalise expectations
 //! spi.done();
 //! ```
+use embedded_hal::nb;
 use embedded_hal::spi::blocking as spi;
 use embedded_hal::spi::blocking::SpiBusFlush;
 use embedded_hal::spi::nb::FullDuplex;
 use embedded_hal::spi::ErrorKind;
 use embedded_hal::spi::ErrorType;
-use nb;
 
 use crate::common::Generic;
 


### PR DESCRIPTION
The `embedded-hal` alpha added a re-export for `nb`.  Using the export will ensure that `nb` versions are always the same between this crate and `embedded-hal`.