### PR TITLE
enable GitHub Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
this ensures that the dependencies are kept up to date. see [the docs][] for further information.

note: there's intentionally no entry in the changelog as it does not have an impact on consumers.

[the docs]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates