### PR TITLE
define the MSRV in `Cargo.toml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
 ## Unreleased
 
 ### Added
@@ -18,6 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Generic` mock: Fix a bug that caused the call to `.done()` to fail if
   `.next()` was called on the mock after all expectations have already been
   consumed (#58)
+
+### Changed
+
+- The minimal supported Rust version (MSRV) is specified in the `Cargo.toml` to
+  offer clearer error messages to consumers with outdated Rust versions
 
 
 ## 0.9.0 - 2023-01-07

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ include = [
     "LICENSE-APACHE",
 ]
 edition = "2021"
+rust-version = "1.60"
 
 [dependencies]
 embedded-hal = { version = "0.2.7", features = ["unproven"] }

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ or no-op implementations are used.
 The goal of the crate is to be able to test drivers in CI without having access
 to hardware.
 
-This crate requires Rust 1.60+!
-
 [Docs](https://docs.rs/embedded-hal-mock/)
 
 
@@ -47,6 +45,12 @@ know.
 ## Usage
 
 See [docs](https://docs.rs/embedded-hal-mock/).
+
+
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*
+compile with older versions but that may change in any new patch release.
 
 
 ## Development Version of `embedded-hal`


### PR DESCRIPTION
this way the compiler will issue a clear error message to consumers using outdated rust versions (rather than cryptic compile errors due to missing features).

also slightly adapted the README to more closely match the MSRV definition of other big crates there.