### PR TITLE
Fix next() on `Generic` mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Fixed
+
+- `Generic` mock: Fix a bug that caused the call to `.done()` to fail if
+  `.next()` was called on the mock after all expectations have already been
+  consumed (#58)
+
+
 ## 0.9.0 - 2023-01-07
 
 ### Added

--- a/src/common.rs
+++ b/src/common.rs
@@ -81,8 +81,11 @@ where
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
         let mut e = self.expected.lock().unwrap();
-        e.0 += 1;
-        e.1.get(e.0 - 1).cloned()
+        let val = e.1.get(e.0).cloned();
+        if val.is_some() {
+            e.0 += 1;
+        }
+        val
     }
 }
 
@@ -98,5 +101,7 @@ mod tests {
         assert_eq!(mock.next(), Some(0u8));
         assert_eq!(mock.next(), Some(1u8));
         assert_eq!(mock.next(), None);
+
+        mock.done();
     }
 }


### PR DESCRIPTION
The implementation of `next()` had a logic error: When called after the expectations have already been exhausted, the index would still get incremented, causing `done()` to fail.

To further simplify the implementation, I replaced the index lookup with a `VecDeque`.