### PR TITLE
Fail if a mock is dropped without having called `.done()` exactly once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Print a warning to stderr if a mock is dropped without having calling
+  `.done()` on it (#59)
+
 ### Fixed
 
 - `Generic` mock: Fix a bug that caused the call to `.done()` to fail if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Print a warning to stderr if a mock is dropped without having calling
-  `.done()` on it (#59)
+- Print a warning to stderr and fail test if a mock is dropped without having
+  calling `.done()` on it, or if `.done()` is called twice (#59)
 
 ### Fixed
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -411,7 +411,7 @@ mod test {
         i2c.read(0xaa, &mut buff).unwrap();
         assert_eq!(vec![1, 2], buff);
 
-        i2c.done();
+        // Call `.done()` on the clone, not on the original instance
         i2c_clone.done();
     }
 


### PR DESCRIPTION
Not calling `.done()` is a potential bug. Print a warning to stderr and fail the test if `done()` is not called exactly once.

I first thought about putting the strict checking behind a feature flag, but it's better to simply release a breaking release (0.10) instead.

Fixes #34.