### PR TITLE
Generic mock: When calling expect, call done internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+
 - Implement mock for `embedded_hal::pwm::SetDutyCycle`
 
 ### Fixed
 
 ### Changed
+
+- When updating expectations on a mock by calling `.expect(...)` on it, assert
+  that previous expectations have been consumed (#63)
 
 
 ## 0.10.0-rc.1 - 2023-11-01
@@ -86,7 +90,7 @@ contributions!
 
 ### Fixed
 
--  Fix link to digital pin docs (#28)
+- Fix link to digital pin docs (#28)
 
 
 ## 0.7.0 - 2019-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- When updating expectations on a mock by calling `.expect(...)` on it, assert
-  that previous expectations have been consumed (#63)
+- Renamed `.expect(...)` method to `.update_expectations(...)` to avoid
+  confusion with the expect method in `Option` and `Result` (#63)
+- When updating expectations on a mock by calling `.expect(...)` /
+  `.update_expectations(...)` on it, assert that previous expectations have
+  been consumed (#63)
 
 
 ## 0.10.0-rc.1 - 2023-11-01

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,7 +9,7 @@ use std::{
 
 /// Generic mock implementation.
 ///
-/// ⚠️ **Do not use this directly as end user! This is only a building block
+/// ⚠️ **Do not create this directly as end user! This is only a building block
 /// for creating mocks.**
 ///
 /// This type supports the specification and evaluation of expectations to
@@ -72,6 +72,18 @@ where
 
         // Reset done call detector
         done_called.reset();
+    }
+
+    /// Deprecated alias of `update_expectations`.
+    #[deprecated(
+        since = "0.10.0",
+        note = "The method 'expect' was renamed to 'update_expectations'"
+    )]
+    pub fn expect<E>(&mut self, expected: E)
+    where
+        E: IntoIterator<Item = &'a T>,
+    {
+        self.update_expectations(expected)
     }
 
     /// Assert that all expectations on a given mock have been consumed.

--- a/src/common.rs
+++ b/src/common.rs
@@ -42,7 +42,7 @@ where
             done_called: Arc::new(Mutex::new(DoneCallDetector::new())),
         };
 
-        g.expect(expected);
+        g.update_expectations(expected);
 
         g
     }
@@ -53,7 +53,7 @@ where
     /// expectations are all consumed by calling [`done()`](#method.done)
     /// internally (if not called already). Afterwards, the new expectations
     /// are set.
-    pub fn expect<E>(&mut self, expected: E)
+    pub fn update_expectations<E>(&mut self, expected: E)
     where
         E: IntoIterator<Item = &'a T>,
     {

--- a/src/eh0/pin.rs
+++ b/src/eh0/pin.rs
@@ -34,7 +34,7 @@
 //! pin.done();
 //!
 //! // Update expectations
-//! pin.expect(&[]);
+//! pin.update_expectations(&[]);
 //! // ...
 //! pin.done();
 //!

--- a/src/eh0/serial.rs
+++ b/src/eh0/serial.rs
@@ -298,10 +298,6 @@ where
 /// if desired.
 #[derive(Clone)]
 pub struct Mock<Word> {
-    /// The expected operations upon the mock
-    ///
-    /// It's in an arc to maintain shared state, and in a mutex
-    /// to make it thread safe.
     expected_modes: Arc<Mutex<VecDeque<Mode<Word>>>>,
     done_called: Arc<Mutex<DoneCallDetector>>,
 }
@@ -313,7 +309,7 @@ impl<Word: Clone> Mock<Word> {
             expected_modes: Arc::new(Mutex::new(VecDeque::new())),
             done_called: Arc::new(Mutex::new(DoneCallDetector::new())),
         };
-        ser.expect(transactions);
+        ser.update_expectations(transactions);
         ser
     }
 
@@ -323,7 +319,7 @@ impl<Word: Clone> Mock<Word> {
     /// expectations are all consumed by calling [`done()`](#method.done)
     /// internally (if not called already). Afterwards, the new expectations
     /// are set.
-    pub fn expect(&mut self, transactions: &[Transaction<Word>]) {
+    pub fn update_expectations(&mut self, transactions: &[Transaction<Word>]) {
         // Ensure that existing expectations are consumed
         self.done_impl(false);
 
@@ -572,7 +568,7 @@ mod test {
         let r = ser.read().expect("failed to read");
         assert_eq!(r, 0x54);
         ser.done();
-        ser.expect(&ts);
+        ser.update_expectations(&ts);
         ser.done();
     }
 

--- a/src/eh0/serial.rs
+++ b/src/eh0/serial.rs
@@ -301,9 +301,8 @@ pub struct Mock<Word> {
     /// The expected operations upon the mock
     ///
     /// It's in an arc to maintain shared state, and in a mutex
-    /// to make it thread safe. It's then wrapped in an `Option`
-    /// so that we can take it in the call to `done()`.
-    expected_modes: Arc<Mutex<Option<VecDeque<Mode<Word>>>>>,
+    /// to make it thread safe.
+    expected_modes: Arc<Mutex<VecDeque<Mode<Word>>>>,
     done_called: Arc<Mutex<DoneCallDetector>>,
 }
 
@@ -311,41 +310,55 @@ impl<Word: Clone> Mock<Word> {
     /// Create a serial mock that will expect the provided transactions
     pub fn new(transactions: &[Transaction<Word>]) -> Self {
         let mut ser = Mock {
-            expected_modes: Arc::new(Mutex::new(None)),
+            expected_modes: Arc::new(Mutex::new(VecDeque::new())),
             done_called: Arc::new(Mutex::new(DoneCallDetector::new())),
         };
         ser.expect(transactions);
         ser
     }
 
-    /// Set expectations on the interface
+    /// Update expectations on the interface
     ///
-    /// This is a list of transactions to be executed in order.
-    /// Note that setting this will overwrite any existing expectations
+    /// When this method is called, first it is ensured that existing
+    /// expectations are all consumed by calling [`done()`](#method.done)
+    /// internally (if not called already). Afterwards, the new expectations
+    /// are set.
     pub fn expect(&mut self, transactions: &[Transaction<Word>]) {
+        // Ensure that existing expectations are consumed
+        self.done_impl(false);
+
+        // Lock internal state
         let mut expected = self.expected_modes.lock().unwrap();
         let mut done_called = self.done_called.lock().unwrap();
-        *expected = Some(
-            transactions
-                .iter()
-                .fold(VecDeque::new(), |mut modes, transaction| {
-                    modes.extend(transaction.mode.clone());
-                    modes
-                }),
-        );
+
+        // Update expectations
+        *expected = transactions
+            .iter()
+            .fold(VecDeque::new(), |mut modes, transaction| {
+                modes.extend(transaction.mode.clone());
+                modes
+            });
+
+        // Reset done call detector
         done_called.reset();
     }
 
     /// Asserts that all expectations up to this point were satisfied.
     /// Panics if there are unsatisfied expectations.
     pub fn done(&mut self) {
-        self.done_called.lock().unwrap().mark_as_called();
+        self.done_impl(true);
+    }
 
-        let mut lock = self
+    fn done_impl(&mut self, panic_if_already_done: bool) {
+        self.done_called
+            .lock()
+            .unwrap()
+            .mark_as_called(panic_if_already_done);
+
+        let modes = self
             .expected_modes
             .lock()
             .expect("unable to lock serial mock in call to done");
-        let modes = lock.take().expect("attempted to take None from Optional");
         assert!(
             modes.is_empty(),
             "serial mock has unsatisfied expectations after call to done"
@@ -354,14 +367,10 @@ impl<Word: Clone> Mock<Word> {
 
     /// Pop the next transaction out of the queue
     fn pop(&mut self) -> Option<Mode<Word>> {
-        let mut lock = self
-            .expected_modes
+        self.expected_modes
             .lock()
-            .expect("unable to lock serial mock in call to pop");
-        let queue = lock
-            .as_mut()
-            .expect("attempt to get queue reference from a None");
-        queue.pop_front()
+            .expect("unable to lock serial mock in call to pop")
+            .pop_front()
     }
 }
 

--- a/src/eh0/serial.rs
+++ b/src/eh0/serial.rs
@@ -339,6 +339,15 @@ impl<Word: Clone> Mock<Word> {
         done_called.reset();
     }
 
+    /// Deprecated alias of `update_expectations`.
+    #[deprecated(
+        since = "0.10.0",
+        note = "The method 'expect' was renamed to 'update_expectations'"
+    )]
+    pub fn expect(&mut self, transactions: &[Transaction<Word>]) {
+        self.update_expectations(transactions)
+    }
+
     /// Asserts that all expectations up to this point were satisfied.
     /// Panics if there are unsatisfied expectations.
     pub fn done(&mut self) {

--- a/src/eh1/pin.rs
+++ b/src/eh1/pin.rs
@@ -34,7 +34,7 @@
 //! pin.done();
 //!
 //! // Update expectations
-//! pin.expect(&[]);
+//! pin.update_expectations(&[]);
 //! // ...
 //! pin.done();
 //!

--- a/src/eh1/serial.rs
+++ b/src/eh1/serial.rs
@@ -299,6 +299,15 @@ impl<Word: Clone> Mock<Word> {
         done_called.reset();
     }
 
+    /// Deprecated alias of `update_expectations`.
+    #[deprecated(
+        since = "0.10.0",
+        note = "The method 'expect' was renamed to 'update_expectations'"
+    )]
+    pub fn expect<E>(&mut self, transactions: &[Transaction<Word>]) {
+        self.update_expectations(transactions)
+    }
+
     /// Asserts that all expectations up to this point were satisfied.
     /// Panics if there are unsatisfied expectations.
     pub fn done(&mut self) {

--- a/src/eh1/serial.rs
+++ b/src/eh1/serial.rs
@@ -261,9 +261,8 @@ pub struct Mock<Word> {
     /// The expected operations upon the mock
     ///
     /// It's in an arc to maintain shared state, and in a mutex
-    /// to make it thread safe. It's then wrapped in an `Option`
-    /// so that we can take it in the call to `done()`.
-    expected_modes: Arc<Mutex<Option<VecDeque<Mode<Word>>>>>,
+    /// to make it thread safe.
+    expected_modes: Arc<Mutex<VecDeque<Mode<Word>>>>,
     done_called: Arc<Mutex<DoneCallDetector>>,
 }
 
@@ -271,41 +270,55 @@ impl<Word: Clone> Mock<Word> {
     /// Create a serial mock that will expect the provided transactions
     pub fn new(transactions: &[Transaction<Word>]) -> Self {
         let mut ser = Mock {
-            expected_modes: Arc::new(Mutex::new(None)),
+            expected_modes: Arc::new(Mutex::new(VecDeque::new())),
             done_called: Arc::new(Mutex::new(DoneCallDetector::new())),
         };
         ser.expect(transactions);
         ser
     }
 
-    /// Set expectations on the interface
+    /// Update expectations on the interface
     ///
-    /// This is a list of transactions to be executed in order.
-    /// Note that setting this will overwrite any existing expectations
+    /// When this method is called, first it is ensured that existing
+    /// expectations are all consumed by calling [`done()`](#method.done)
+    /// internally (if not called already). Afterwards, the new expectations
+    /// are set.
     pub fn expect(&mut self, transactions: &[Transaction<Word>]) {
+        // Ensure that existing expectations are consumed
+        self.done_impl(false);
+
+        // Lock internal state
         let mut expected = self.expected_modes.lock().unwrap();
         let mut done_called = self.done_called.lock().unwrap();
-        *expected = Some(
-            transactions
-                .iter()
-                .fold(VecDeque::new(), |mut modes, transaction| {
-                    modes.extend(transaction.mode.clone());
-                    modes
-                }),
-        );
+
+        // Update expectations
+        *expected = transactions
+            .iter()
+            .fold(VecDeque::new(), |mut modes, transaction| {
+                modes.extend(transaction.mode.clone());
+                modes
+            });
+
+        // Reset done call detector
         done_called.reset();
     }
 
     /// Asserts that all expectations up to this point were satisfied.
     /// Panics if there are unsatisfied expectations.
     pub fn done(&mut self) {
-        self.done_called.lock().unwrap().mark_as_called();
+        self.done_impl(true);
+    }
 
-        let mut lock = self
+    fn done_impl(&mut self, panic_if_already_done: bool) {
+        self.done_called
+            .lock()
+            .unwrap()
+            .mark_as_called(panic_if_already_done);
+
+        let modes = self
             .expected_modes
             .lock()
             .expect("unable to lock serial mock in call to done");
-        let modes = lock.take().expect("attempted to take None from Optional");
         assert!(
             modes.is_empty(),
             "serial mock has unsatisfied expectations after call to done"
@@ -314,14 +327,10 @@ impl<Word: Clone> Mock<Word> {
 
     /// Pop the next transaction out of the queue
     fn pop(&mut self) -> Option<Mode<Word>> {
-        let mut lock = self
-            .expected_modes
+        self.expected_modes
             .lock()
-            .expect("unable to lock serial mock in call to pop");
-        let queue = lock
-            .as_mut()
-            .expect("attempt to get queue reference from a None");
-        queue.pop_front()
+            .expect("unable to lock serial mock in call to pop")
+            .pop_front()
     }
 }
 

--- a/src/eh1/serial.rs
+++ b/src/eh1/serial.rs
@@ -258,10 +258,6 @@ where
 /// if desired.
 #[derive(Clone)]
 pub struct Mock<Word> {
-    /// The expected operations upon the mock
-    ///
-    /// It's in an arc to maintain shared state, and in a mutex
-    /// to make it thread safe.
     expected_modes: Arc<Mutex<VecDeque<Mode<Word>>>>,
     done_called: Arc<Mutex<DoneCallDetector>>,
 }
@@ -273,7 +269,7 @@ impl<Word: Clone> Mock<Word> {
             expected_modes: Arc::new(Mutex::new(VecDeque::new())),
             done_called: Arc::new(Mutex::new(DoneCallDetector::new())),
         };
-        ser.expect(transactions);
+        ser.update_expectations(transactions);
         ser
     }
 
@@ -283,7 +279,7 @@ impl<Word: Clone> Mock<Word> {
     /// expectations are all consumed by calling [`done()`](#method.done)
     /// internally (if not called already). Afterwards, the new expectations
     /// are set.
-    pub fn expect(&mut self, transactions: &[Transaction<Word>]) {
+    pub fn update_expectations(&mut self, transactions: &[Transaction<Word>]) {
         // Ensure that existing expectations are consumed
         self.done_impl(false);
 
@@ -478,7 +474,7 @@ mod test {
         let r = ser.read().expect("failed to read");
         assert_eq!(r, 0x54);
         ser.done();
-        ser.expect(&ts);
+        ser.update_expectations(&ts);
         ser.done();
     }
 


### PR DESCRIPTION
When updating expectations on a mock by calling `.expect(...)` on it, assert that previous expectations have been consumed. (We discussed this in Matrix, @ryankurte.)

Open questions:

- Should we rename `expect`, to avoid confusion with the method with the same name on `Result` and `Option`? I'd suggest `update_expectations`. This is a breaking change, but it's a semver-breaking release anyways.
- Should it be legal to call  `.expect(...)` after calling `.done(...)`? For now, I added a check which ignores double-done when calling `.expect(...)`.

Another issue: Right now we have two separate state variables in an `Arc<Mutex<_>>` that need to be locked independently. This smells racy, it would probably be good to have a single lock for the internal shared state.