### PR TITLE
Stricter panic assertions

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -161,24 +161,25 @@ mod tests {
         }
 
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "WARNING: A mock (from embedded-hal-mock) was dropped without calling the `.done()` method. See https://github.com/dbrgn/embedded-hal-mock/issues/34 for more details."
+        )]
         fn panic_if_drop_not_called() {
             let expectations = [0u8, 1u8];
             let mut mock: Generic<u8> = Generic::new(&expectations);
             assert_eq!(mock.next(), Some(0u8));
             assert_eq!(mock.next(), Some(1u8));
-            // Note: done() not called
         }
 
         #[test]
-        #[should_panic]
+        #[should_panic(expected = "The `.done()` method was called twice!")]
         fn panic_if_drop_called_twice() {
             let expectations = [0u8, 1u8];
             let mut mock: Generic<u8> = Generic::new(&expectations);
             assert_eq!(mock.next(), Some(0u8));
             assert_eq!(mock.next(), Some(1u8));
             mock.done();
-            mock.done(); // This will panic
+            mock.done();
         }
     }
 }

--- a/src/eh0/i2c.rs
+++ b/src/eh0/i2c.rs
@@ -338,37 +338,41 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[1, 2]`,\n right: `[1, 3]`: i2c::write data does not match expectation"
+    )]
     fn write_data_mismatch() {
         let expectations = [Transaction::write(0xaa, vec![1, 2])];
         let mut i2c = Mock::new(&expectations);
 
-        let _ = i2c.write(0xaa, &vec![1, 3]); // Panics because unexpected data was written
+        let _ = i2c.write(0xaa, &vec![1, 3]);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `Read`,\n right: `Write`: i2c::write unexpected mode"
+    )]
     fn transaction_type_mismatch() {
         let expectations = [Transaction::read(0xaa, vec![10, 12])];
         let mut i2c = Mock::new(&expectations);
 
         let mut buff = vec![0; 2];
-        let _ = i2c.write(0xaa, &mut buff); // Panics because it's a write, not a read
+        let _ = i2c.write(0xaa, &mut buff);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "i2c::write_read address mismatch")]
     fn address_mismatch() {
         let expectations = [Transaction::write_read(0xbb, vec![1, 2], vec![3, 4])];
         let mut i2c = Mock::new(&expectations);
 
         let v = vec![1, 2];
         let mut buff = vec![0; 2];
-        let _ = i2c.write_read(0xaa, &v, &mut buff); // Panics because an unexpected address was used
+        let _ = i2c.write_read(0xaa, &v, &mut buff);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Not all expectations consumed")]
     fn unconsumed_expectations() {
         let expectations = [
             Transaction::write(0xaa, vec![10, 12]),
@@ -378,7 +382,7 @@ mod test {
 
         i2c.write(0xaa, &vec![10, 12]).unwrap();
 
-        i2c.done(); // Panics because not all transactions were consumed
+        i2c.done();
     }
 
     #[test]
@@ -428,21 +432,25 @@ mod test {
 
         /// The transaction mode should still be validated.
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "assertion failed: `(left == right)`\n  left: `Write`,\n right: `Read`: i2c::read unexpected mode"
+        )]
         fn write_wrong_mode() {
             let mut i2c = Mock::new(&[Transaction::write(0xaa, vec![10, 12])
                 .with_error(MockError::Io(IoErrorKind::Other))]);
             let mut buf = vec![0; 2];
-            let _ = i2c.read(0xaa, &mut buf); // Panics because it's a read, not a write
+            let _ = i2c.read(0xaa, &mut buf);
         }
 
         /// The transaction bytes should still be validated.
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 13]`: i2c::write data does not match expectation"
+        )]
         fn write_wrong_data() {
             let mut i2c = Mock::new(&[Transaction::write(0xaa, vec![10, 12])
                 .with_error(MockError::Io(IoErrorKind::Other))]);
-            let _ = i2c.write(0xaa, &vec![10, 13]); // Panics because unexpected data was written
+            let _ = i2c.write(0xaa, &vec![10, 13]);
         }
 
         #[test]
@@ -471,12 +479,14 @@ mod test {
 
         /// The transaction bytes should still be validated.
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 13]`: i2c::write_read write data does not match expectation"
+        )]
         fn write_read_wrong_data() {
             let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
                 .with_error(MockError::Io(IoErrorKind::Other))]);
             let mut buf = vec![0; 2];
-            let _ = i2c.write_read(0xaa, &vec![10, 13], &mut buf); // Panics because unexpected data was written
+            let _ = i2c.write_read(0xaa, &vec![10, 13], &mut buf);
         }
     }
 }

--- a/src/eh0/serial.rs
+++ b/src/eh0/serial.rs
@@ -515,7 +515,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "unsatisfied expectations")]
+    #[should_panic(expected = "serial mock has unsatisfied expectations after call to done")]
     fn test_serial_mock_blocking_write_not_enough() {
         let ts = [Transaction::write_many([0xAB, 0xCD, 0xEF, 0x00])];
         let mut ser = Mock::new(&ts);
@@ -524,7 +524,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "serial::write expected to write")]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `18`,\n right: `20`: serial::write expected to write 18 but actually wrote 20"
+    )]
     fn test_serial_mock_wrong_write() {
         let ts = [Transaction::write(0x12)];
         let mut ser = Mock::new(&ts);
@@ -548,7 +550,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "unsatisfied expectations")]
+    #[should_panic(expected = "serial mock has unsatisfied expectations after call to done")]
     fn test_serial_mock_pending_transactions() {
         let ts = [Transaction::read(0x54)];
         let mut ser = Mock::new(&ts);
@@ -556,7 +558,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "unsatisfied expectations")]
+    #[should_panic(expected = "serial mock has unsatisfied expectations after call to done")]
     fn test_serial_mock_reuse_pending_transactions() {
         let ts = [Transaction::read(0x54)];
         let mut ser = Mock::new(&ts);
@@ -568,7 +570,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "expected to perform a serial transaction 'Read(")]
+    #[should_panic(
+        expected = "expected to perform a serial transaction 'Read(84)' but instead did a write of 119"
+    )]
     fn test_serial_mock_expected_read() {
         let ts = [Transaction::read(0x54)];
         let mut ser = Mock::new(&ts);
@@ -576,7 +580,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "expected to perform a serial transaction 'Write(")]
+    #[should_panic(
+        expected = "expected to perform a serial transaction 'Write(84)' but instead did a flush"
+    )]
     fn test_serial_mock_expected_write() {
         let ts = [Transaction::write(0x54)];
         let mut ser = Mock::new(&ts);
@@ -584,7 +590,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "expected to perform a serial transaction 'Flush'")]
+    #[should_panic(
+        expected = "expected to perform a serial transaction 'Flush', but instead did a read"
+    )]
     fn test_serial_mock_expected_flush() {
         let ts = [Transaction::flush()];
         let mut ser: Mock<u128> = Mock::new(&ts);
@@ -610,7 +618,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "serial::write expected to write 42 but actually wrote 23")]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `42`,\n right: `23`: serial::write expected to write 42 but actually wrote 23"
+    )]
     fn test_serial_mock_write_error_wrong_data() {
         let error = nb::Error::Other(MockError::Io(io::ErrorKind::NotConnected));
         let ts = [Transaction::write_error(42, error.clone())];

--- a/src/eh0/spi.rs
+++ b/src/eh0/spi.rs
@@ -323,7 +323,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 12, 12]`: spi::write data does not match expectation"
+    )]
     fn test_spi_mock_write_err() {
         let expectations = [Transaction::write(vec![10, 12])];
         let mut spi = Mock::new(&expectations);
@@ -334,7 +336,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 12, 12]`: spi::write_iter data does not match expectation"
+    )]
     fn test_spi_mock_write_iter_err() {
         let expectations = [Transaction::write(vec![10, 12])];
         let mut spi = Mock::new(&expectations);
@@ -345,7 +349,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[12, 15]`,\n right: `[12, 13]`"
+    )]
     fn test_spi_mock_transfer_err() {
         let expectations = [Transaction::transfer(vec![10, 12], vec![12, 15])];
         let mut spi = Mock::new(&expectations);
@@ -359,7 +365,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[1, 2]`,\n right: `[10, 12]`: spi::write data does not match expectation"
+    )]
     fn test_spi_mock_transfer_response_err() {
         let expectations = [Transaction::transfer(vec![1, 2], vec![3, 4, 5])];
         let mut spi = Mock::new(&expectations);
@@ -373,7 +381,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `Transfer`,\n right: `Write`: spi::write unexpected mode"
+    )]
     fn test_spi_mock_mode_err() {
         let expectations = [Transaction::transfer(vec![10, 12], vec![])];
         let mut spi = Mock::new(&expectations);
@@ -384,7 +394,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 12, 12]`: spi::write data does not match expectation"
+    )]
     fn test_spi_mock_multiple_transaction_err() {
         let expectations = [
             Transaction::write(vec![10, 12]),

--- a/src/eh1/i2c.rs
+++ b/src/eh1/i2c.rs
@@ -384,37 +384,45 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[1, 2]`,\n right: `[1, 3]`: i2c::write data does not match expectation"
+    )]
     fn write_data_mismatch() {
         let expectations = [Transaction::write(0xaa, vec![1, 2])];
         let mut i2c = Mock::new(&expectations);
 
-        i2c.write(0xaa, &vec![1, 3]).unwrap(); // Panics because unexpected data was written
+        i2c.write(0xaa, &vec![1, 3]).unwrap();
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `Read`,\n right: `Write`: i2c::write unexpected mode"
+    )]
     fn transaction_type_mismatch() {
         let expectations = [Transaction::read(0xaa, vec![10, 12])];
         let mut i2c = Mock::new(&expectations);
 
         let mut buff = vec![0; 2];
-        i2c.write(0xaa, &mut buff).unwrap(); // Panics because it's a write, not a read
+        i2c.write(0xaa, &mut buff).unwrap();
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `187`,\n right: `170`: i2c::write_read address mismatch"
+    )]
     fn address_mismatch() {
         let expectations = [Transaction::write_read(0xbb, vec![1, 2], vec![3, 4])];
         let mut i2c = Mock::new(&expectations);
 
         let v = vec![1, 2];
         let mut buff = vec![0; 2];
-        i2c.write_read(0xaa, &v, &mut buff).unwrap(); // Panics because an unexpected address was used
+        i2c.write_read(0xaa, &v, &mut buff).unwrap();
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `Read`,\n right: `Write`: i2c::write unexpected mode"
+    )]
     fn test_i2c_mock_mode_err() {
         let expectations = [Transaction::read(0xaa, vec![10, 12])];
         let mut i2c = Mock::new(&expectations);
@@ -425,7 +433,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Not all expectations consumed")]
     fn unconsumed_expectations() {
         let expectations = [
             Transaction::write(0xaa, vec![10, 12]),
@@ -435,7 +443,7 @@ mod test {
 
         i2c.write(0xaa, &vec![10, 12]).unwrap();
 
-        i2c.done(); // Panics because not all transactions were consumed
+        i2c.done();
     }
 
     #[test]
@@ -485,21 +493,25 @@ mod test {
 
         /// The transaction mode should still be validated.
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "assertion failed: `(left == right)`\n  left: `Write`,\n right: `Read`: i2c::read unexpected mode"
+        )]
         fn write_wrong_mode() {
             let mut i2c =
                 Mock::new(&[Transaction::write(0xaa, vec![10, 12]).with_error(ErrorKind::Other)]);
             let mut buf = vec![0; 2];
-            let _ = i2c.read(0xaa, &mut buf); // Panics because it's a read, not a write
+            let _ = i2c.read(0xaa, &mut buf);
         }
 
         /// The transaction bytes should still be validated.
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 13]`: i2c::write data does not match expectation"
+        )]
         fn write_wrong_data() {
             let mut i2c =
                 Mock::new(&[Transaction::write(0xaa, vec![10, 12]).with_error(ErrorKind::Other)]);
-            let _ = i2c.write(0xaa, &vec![10, 13]); // Panics because unexpected data was written
+            let _ = i2c.write(0xaa, &vec![10, 13]);
         }
 
         #[test]
@@ -517,7 +529,9 @@ mod test {
 
         /// The transaction mode should still be validated.
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "assertion failed: `(left == right)`\n  left: `Read`,\n right: `Write`: i2c::write unexpected mode"
+        )]
         fn read_wrong_mode() {
             let mut i2c =
                 Mock::new(&[Transaction::read(0xaa, vec![10, 12]).with_error(ErrorKind::Other)]);
@@ -537,7 +551,9 @@ mod test {
 
         /// The transaction mode should still be validated.
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "assertion failed: `(left == right)`\n  left: `WriteRead`,\n right: `Write`: i2c::write unexpected mode"
+        )]
         fn write_read_wrong_mode() {
             let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
                 .with_error(ErrorKind::Other)]);
@@ -546,7 +562,9 @@ mod test {
 
         /// The transaction bytes should still be validated.
         #[test]
-        #[should_panic]
+        #[should_panic(
+            expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 13]`: i2c::write_read write data does not match expectation"
+        )]
         fn write_read_wrong_data() {
             let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
                 .with_error(ErrorKind::Other)]);

--- a/src/eh1/serial.rs
+++ b/src/eh1/serial.rs
@@ -517,7 +517,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "unsatisfied expectations")]
+    #[should_panic(expected = "serial mock has unsatisfied expectations after call to done")]
     fn test_serial_mock_blocking_write_not_enough() {
         use embedded_hal::serial::Write as BWrite;
         let ts = [Transaction::write_many([0xAB, 0xCD, 0xEF, 0x00])];
@@ -527,7 +527,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "serial::write expected to write")]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `18`,\n right: `20`: serial::write expected to write 18 but actually wrote 20"
+    )]
     fn test_serial_mock_wrong_write() {
         let ts = [Transaction::write(0x12)];
         let mut ser = Mock::new(&ts);
@@ -552,7 +554,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "unsatisfied expectations")]
+    #[should_panic(expected = "serial mock has unsatisfied expectations after call to done")]
     fn test_serial_mock_pending_transactions() {
         let ts = [Transaction::read(0x54)];
         let mut ser = Mock::new(&ts);
@@ -560,7 +562,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "unsatisfied expectations")]
+    #[should_panic(expected = "serial mock has unsatisfied expectations after call to done")]
     fn test_serial_mock_reuse_pending_transactions() {
         let ts = [Transaction::read(0x54)];
         let mut ser = Mock::new(&ts);
@@ -572,7 +574,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "expected to perform a serial transaction 'Read(")]
+    #[should_panic(
+        expected = "expected to perform a serial transaction 'Read(84)' but instead did a write of 119"
+    )]
     fn test_serial_mock_expected_read() {
         use embedded_hal::serial::Write as BWrite;
         let ts = [Transaction::read(0x54)];
@@ -581,7 +585,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "expected to perform a serial transaction 'Write(")]
+    #[should_panic(
+        expected = "expected to perform a serial transaction 'Write(84)' but instead did a flush"
+    )]
     fn test_serial_mock_expected_write() {
         let ts = [Transaction::write(0x54)];
         let mut ser = Mock::new(&ts);
@@ -589,7 +595,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "expected to perform a serial transaction 'Flush'")]
+    #[should_panic(
+        expected = "expected to perform a serial transaction 'Flush', but instead did a read"
+    )]
     fn test_serial_mock_expected_flush() {
         let ts = [Transaction::flush()];
         let mut ser: Mock<u128> = Mock::new(&ts);
@@ -615,7 +623,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "serial::write expected to write 42 but actually wrote 23")]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `42`,\n right: `23`: serial::write expected to write 42 but actually wrote 23"
+    )]
     fn test_serial_mock_write_error_wrong_data() {
         let error = nb::Error::Other(ErrorKind::Parity);
         let ts = [Transaction::write_error(42, error.clone())];

--- a/src/eh1/spi.rs
+++ b/src/eh1/spi.rs
@@ -772,7 +772,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 12, 12]`: spi::write data does not match expectation"
+    )]
     fn test_spi_mock_write_err() {
         use embedded_hal::spi::SpiBusWrite;
 
@@ -786,7 +788,9 @@ mod test {
 
     #[tokio::test]
     #[cfg(feature = "embedded-hal-async")]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 12, 12]`: spi::write data does not match expectation"
+    )]
     async fn test_async_spi_mock_write_err() {
         use embedded_hal_async::spi::SpiBusWrite;
 
@@ -799,7 +803,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[12, 15]`,\n right: `[12, 13]`"
+    )]
     fn test_spi_mock_transfer_err() {
         use embedded_hal::spi::SpiBus;
 
@@ -816,7 +822,9 @@ mod test {
 
     #[tokio::test]
     #[cfg(feature = "embedded-hal-async")]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[12, 15]`,\n right: `[12, 13]`"
+    )]
     async fn test_async_spi_mock_transfer_err() {
         use embedded_hal_async::spi::SpiBus;
 
@@ -832,7 +840,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[1, 2]`,\n right: `[10, 12]`: spi::write data does not match expectation"
+    )]
     fn test_spi_mock_transfer_response_err() {
         use embedded_hal::spi::SpiBus;
 
@@ -849,7 +859,9 @@ mod test {
 
     #[tokio::test]
     #[cfg(feature = "embedded-hal-async")]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[1, 2]`,\n right: `[10, 12]`: spi::write data does not match expectation"
+    )]
     async fn test_async_spi_mock_transfer_response_err() {
         use embedded_hal_async::spi::SpiBus;
 
@@ -865,7 +877,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "(left == right)`\n  left: `TransferInplace`,\n right: `Write`: spi::write unexpected mode"
+    )]
     fn test_spi_mock_mode_err() {
         use embedded_hal::spi::SpiBusWrite;
 
@@ -879,7 +893,9 @@ mod test {
 
     #[tokio::test]
     #[cfg(feature = "embedded-hal-async")]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `TransferInplace`,\n right: `Write`: spi::write unexpected mode"
+    )]
     async fn test_async_spi_mock_mode_err() {
         use embedded_hal_async::spi::SpiBusWrite;
 
@@ -892,7 +908,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 12, 12]`: spi::write data does not match expectation"
+    )]
     fn test_spi_mock_multiple_transaction_err() {
         use embedded_hal::spi::SpiBusWrite;
 
@@ -909,7 +927,9 @@ mod test {
 
     #[tokio::test]
     #[cfg(feature = "embedded-hal-async")]
-    #[should_panic]
+    #[should_panic(
+        expected = "assertion failed: `(left == right)`\n  left: `[10, 12]`,\n right: `[10, 12, 12]`: spi::write data does not match expectation"
+    )]
     async fn test_async_spi_mock_multiple_transaction_err() {
         use embedded_hal_async::spi::SpiBusWrite;
 


### PR DESCRIPTION
Assertions on the message of the panic could be helpful for further development eg. adding labels to expectations (they would be included in messages)
Also helps tests document themselves better without comments.