### PR TITLE
docs: add doc_auto_cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ void = { version = "^1.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.21.1", features = ["rt", "macros"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
     feature(async_fn_in_trait),
     allow(incomplete_features)
 )]
+#![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 
 pub mod common;


### PR DESCRIPTION
This adds features hints in the documentation that gets published to docsrs.  e.g. [syn](https://docs.rs/syn/latest/syn/#modules)

Test locally with: `cargo rustdoc --all-features -- --cfg docsrs`