### PR TITLE
README: update min-rust-badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,6 @@ be dual licensed as above, without any additional terms or conditions.
 <!-- Badges -->
 [github-actions]: https://github.com/dbrgn/embedded-hal-mock/actions/workflows/ci.yml
 [github-actions-badge]: https://github.com/dbrgn/embedded-hal-mock/actions/workflows/ci.yml/badge.svg
-[min-rust-badge]: https://img.shields.io/badge/rustc-1.31+-blue.svg
+[min-rust-badge]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [crates-io]: https://crates.io/crates/embedded-hal-mock
 [version-badge]: https://img.shields.io/crates/v/embedded-hal-mock.svg


### PR DESCRIPTION
Updates the min-rust-badge to match documentation and the `rust-version` field in Cargo.toml