### PR TITLE
embedded-hal: 1.0.0-alpha.10 -> 1.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ default = ["eh0", "embedded-time"]
 
 [dependencies]
 eh0 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"], optional = true }
-eh1 = { package = "embedded-hal", version = "=1.0.0-alpha.10", optional = true }
-embedded-hal-nb = { version = "=1.0.0-alpha.2", optional = true }
-embedded-hal-async = { version = "=0.2.0-alpha.1", optional = true }
+eh1 = { package = "embedded-hal", version = "=1.0.0-rc.1", optional = true }
+embedded-hal-nb = { version = "=1.0.0-rc.1", optional = true }
+embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-time = { version = "0.12", optional = true }
 nb = { version = "0.1.1", optional = true}
 void = { version = "^1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,6 @@
 //!
 //! Currently this crate is not `no_std`. If you think this is important, let
 //! me know.
-#![cfg_attr(
-    feature = "embedded-hal-async",
-    feature(async_fn_in_trait),
-    allow(incomplete_features)
-)]
 #![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
Closes #85
Closes #76

The embedded_hal blocking serial module was removed, it was replaced with embedded_io, but I think this makes more sense as a separate mock since it no longer has the Word generic.