### PR TITLE
Add support for embedded_hal_async::digital::Wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ me know.
 | Actual delay                                | ✅           | ✅               |
 | Serial                                      | ✅           | -                |
 | RNG                                         | -            | -                |
-| I/O pins (including PWM)                    | ✅           | -                |
+| I/O pins (including PWM)                    | ✅           | ✅               |
 | ADC                                         | ✅           | -                |
 | Timers (with `embedded-time` Cargo feature) | ✅           | -                |
 


### PR DESCRIPTION
This PR adds support for the async [`Wait`](https://docs.rs/embedded-hal-async/0.2.0-alpha.1/embedded_hal_async/digital/trait.Wait.html) trait from the `embedded-hal-async` crate.