### PR TITLE
Add a `NoDetails` variant for `MockError`

### DIFF
--- a/src/eh0/error.rs
+++ b/src/eh0/error.rs
@@ -3,6 +3,9 @@ use std::{error::Error as StdError, fmt, io};
 /// Errors that may occur during mocking.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum MockError {
+    /// An error occurred without any details.
+    NoDetails,
+
     /// An I/O-Error occurred
     Io(io::ErrorKind),
 }
@@ -16,6 +19,7 @@ impl From<io::Error> for MockError {
 impl fmt::Display for MockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            MockError::NoDetails => write!(f, "An error occurred without any details"),
             MockError::Io(kind) => write!(f, "I/O error: {:?}", kind),
         }
     }

--- a/src/eh1/error.rs
+++ b/src/eh1/error.rs
@@ -6,6 +6,9 @@ use embedded_hal::digital::ErrorKind::{self, Other};
 /// Errors that may occur during mocking.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum MockError {
+    /// An error occurred without any details.
+    NoDetails,
+
     /// An I/O-Error occurred
     Io(io::ErrorKind),
 }
@@ -25,6 +28,7 @@ impl From<io::Error> for MockError {
 impl fmt::Display for MockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            MockError::NoDetails => write!(f, "An error occurred without any details"),
             MockError::Io(kind) => write!(f, "I/O error: {:?}", kind),
         }
     }


### PR DESCRIPTION
Currently, in `no_std` projects it is required to include the std library to test with mocks that return errors, this is because the only supported `MockError` is one that takes a `std::io::ErrorKind`. By adding this new variant that doesn't depend on the std library we can keep the project `no_std` even for testing.

I am open to other names if `NoDetails` is not a good fit. It might be nice to have separate errors for each type of mock e.g. `MockError::Adc(AdcError::InvalidData)` but the way in this PR requires fewer changes.

Thanks.