### PR TITLE
CI: test against rustc 1.75 instead of nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         toolchain:
           - "1.63"
-          - "nightly"
+          - "1.75"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -36,14 +36,14 @@ jobs:
       - name: Build
         run: cargo build
       - name: Build (all features)
-        if: ${{ matrix.toolchain == 'nightly' }}
+        if: ${{ matrix.toolchain == '1.75' }}
         run: cargo build --all-features
 
       # Test main crate
       - name: Test
         run: cargo test
       - name: Test (all features)
-        if: ${{ matrix.toolchain == 'nightly' }}
+        if: ${{ matrix.toolchain == '1.75' }}
         run: cargo test --all-features
 
   # Check code formatting


### PR DESCRIPTION
nightly was only needed for some unstable features which have been stabilised in 1.75.

the alternative to this commit would be to just increase the MSRV of the crate to 1.75 (even though it's only 1.75 when using the async feature) and test against 1.75 only (instead of also testing against 1.63).