### PR TITLE
update to `nb` 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ eh1 = { package = "embedded-hal", version = "1.0", optional = true }
 embedded-hal-nb = { version = "1.0", optional = true }
 embedded-hal-async = { version = "1.0", optional = true }
 embedded-time = { version = "0.12", optional = true }
-nb = { version = "0.1.1", optional = true}
+nb = { version = "1.1", optional = true }
 void = { version = "^1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
0.1.3 internally anyway already forwarded everything to 1, so there's no reason to depend on 0.1 anymore.