### PR TITLE
Use semver in e-h docs.rs links

### DIFF
--- a/src/eh1/pin.rs
+++ b/src/eh1/pin.rs
@@ -1,7 +1,7 @@
 //! Mock digital [`InputPin`] and [`OutputPin`] implementations
 //!
-//! [`InputPin`]: https://docs.rs/embedded-hal/1.0.0/embedded_hal/digital/trait.InputPin.html
-//! [`OutputPin`]: https://docs.rs/embedded-hal/1.0.0/embedded_hal/digital/trait.OutputPin.html
+//! [`InputPin`]: https://docs.rs/embedded-hal/1/embedded_hal/digital/trait.InputPin.html
+//! [`OutputPin`]: https://docs.rs/embedded-hal/1/embedded_hal/digital/trait.OutputPin.html
 //!
 //! ```
 //! # use eh1 as embedded_hal;

--- a/src/eh1/pwm.rs
+++ b/src/eh1/pwm.rs
@@ -1,5 +1,5 @@
 //! Mock implementations for
-//! [`embedded_hal::pwm`](https://docs.rs/embedded-hal/1.0.0/embedded_hal/pwm/index.html).
+//! [`embedded_hal::pwm`](https://docs.rs/embedded-hal/1/embedded_hal/pwm/index.html).
 //!
 //! Usage example:
 //! ```


### PR DESCRIPTION
They should redirect to the latest compatible version.