### PR TITLE
Remove redundant async tests, do some cleanup

### DIFF
--- a/src/eh0/i2c.rs
+++ b/src/eh0/i2c.rs
@@ -302,9 +302,9 @@ mod test {
         let expectations = [Transaction::read(0xaa, vec![1, 2])];
         let mut i2c = Mock::new(&expectations);
 
-        let mut buff = vec![0; 2];
-        i2c.read(0xaa, &mut buff).unwrap();
-        assert_eq!(vec![1, 2], buff);
+        let mut buf = vec![0; 2];
+        i2c.read(0xaa, &mut buf).unwrap();
+        assert_eq!(vec![1, 2], buf);
 
         i2c.done();
     }
@@ -315,9 +315,9 @@ mod test {
         let mut i2c = Mock::new(&expectations);
 
         let v = vec![1, 2];
-        let mut buff = vec![0; 2];
-        i2c.write_read(0xaa, &v, &mut buff).unwrap();
-        assert_eq!(vec![3, 4], buff);
+        let mut buf = vec![0; 2];
+        i2c.write_read(0xaa, &v, &mut buf).unwrap();
+        assert_eq!(vec![3, 4], buf);
 
         i2c.done();
     }
@@ -354,8 +354,8 @@ mod test {
         let expectations = [Transaction::read(0xaa, vec![10, 12])];
         let mut i2c = Mock::new(&expectations);
 
-        let mut buff = vec![0; 2];
-        let _ = i2c.write(0xaa, &mut buff);
+        let mut buf = vec![0; 2];
+        let _ = i2c.write(0xaa, &mut buf);
     }
 
     #[test]
@@ -365,8 +365,8 @@ mod test {
         let mut i2c = Mock::new(&expectations);
 
         let v = vec![1, 2];
-        let mut buff = vec![0; 2];
-        let _ = i2c.write_read(0xaa, &v, &mut buff);
+        let mut buf = vec![0; 2];
+        let _ = i2c.write_read(0xaa, &v, &mut buf);
     }
 
     #[test]
@@ -395,9 +395,9 @@ mod test {
         let mut i2c_clone = i2c.clone();
 
         // Read on the original mock
-        let mut buff = vec![0; 2];
-        i2c.read(0xaa, &mut buff).unwrap();
-        assert_eq!(vec![1, 2], buff);
+        let mut buf = vec![0; 2];
+        i2c.read(0xaa, &mut buf).unwrap();
+        assert_eq!(vec![1, 2], buf);
 
         // Write on the clone
         i2c_clone.write(0xbb, &[3, 4]).unwrap();

--- a/src/eh1/i2c.rs
+++ b/src/eh1/i2c.rs
@@ -65,10 +65,7 @@
 //! ```
 
 use eh1 as embedded_hal;
-use embedded_hal::{
-    i2c,
-    i2c::{ErrorKind, ErrorType, I2c},
-};
+use embedded_hal::i2c::{self, ErrorKind, ErrorType, I2c};
 
 use crate::common::Generic;
 

--- a/src/eh1/i2c.rs
+++ b/src/eh1/i2c.rs
@@ -331,18 +331,6 @@ mod test {
         i2c.done();
     }
 
-    #[tokio::test]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn write_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [Transaction::write(0xaa, vec![10, 12])];
-        let mut i2c = Mock::new(&expectations);
-
-        I2c::write(&mut i2c, 0xaa, &vec![10, 12]).await.unwrap();
-
-        i2c.done();
-    }
-
     #[test]
     fn read() {
         let expectations = [Transaction::read(0xaa, vec![1, 2])];
@@ -350,20 +338,6 @@ mod test {
 
         let mut buff = vec![0; 2];
         i2c.read(0xaa, &mut buff).unwrap();
-        assert_eq!(vec![1, 2], buff);
-
-        i2c.done();
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn read_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [Transaction::read(0xaa, vec![1, 2])];
-        let mut i2c = Mock::new(&expectations);
-
-        let mut buff = vec![0; 2];
-        I2c::read(&mut i2c, 0xaa, &mut buff).await.unwrap();
         assert_eq!(vec![1, 2], buff);
 
         i2c.done();
@@ -382,23 +356,6 @@ mod test {
         i2c.done();
     }
 
-    #[tokio::test]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn write_read_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [Transaction::write_read(0xaa, vec![1, 2], vec![3, 4])];
-        let mut i2c = Mock::new(&expectations);
-
-        let v = vec![1, 2];
-        let mut buff = vec![0; 2];
-        I2c::write_read(&mut i2c, 0xaa, &v, &mut buff)
-            .await
-            .unwrap();
-        assert_eq!(vec![3, 4], buff);
-
-        i2c.done();
-    }
-
     #[test]
     fn multiple_transactions() {
         let expectations = [
@@ -411,26 +368,6 @@ mod test {
 
         let mut v = vec![0; 2];
         i2c.read(0xbb, &mut v).unwrap();
-
-        assert_eq!(v, vec![3, 4]);
-
-        i2c.done();
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn multiple_transactions_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [
-            Transaction::write(0xaa, vec![1, 2]),
-            Transaction::read(0xbb, vec![3, 4]),
-        ];
-        let mut i2c = Mock::new(&expectations);
-
-        I2c::write(&mut i2c, 0xaa, &vec![1, 2]).await.unwrap();
-
-        let mut v = vec![0; 2];
-        I2c::read(&mut i2c, 0xbb, &mut v).await.unwrap();
 
         assert_eq!(v, vec![3, 4]);
 
@@ -462,35 +399,6 @@ mod test {
         i2c.done();
     }
 
-    #[tokio::test]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn test_i2c_mock_multiple_transaction_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [
-            Transaction::transaction_start(0xaa),
-            Transaction::write(0xaa, vec![1, 2]),
-            Transaction::read(0xaa, vec![3, 4]),
-            Transaction::transaction_end(0xaa),
-        ];
-        let mut i2c = Mock::new(&expectations);
-
-        let mut v = vec![0u8; 2];
-        I2c::transaction(
-            &mut i2c,
-            0xaa,
-            &mut [
-                i2c::Operation::Write(&vec![1, 2]),
-                i2c::Operation::Read(&mut v),
-            ],
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(v, vec![3, 4]);
-
-        i2c.done();
-    }
-
     #[test]
     #[should_panic(expected = "i2c::write data does not match expectation")]
     fn write_data_mismatch() {
@@ -498,17 +406,6 @@ mod test {
         let mut i2c = Mock::new(&expectations);
 
         i2c.write(0xaa, &vec![1, 3]).unwrap();
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "i2c::write data does not match expectation")]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn write_data_mismatch_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [Transaction::write(0xaa, vec![1, 2])];
-        let mut i2c = Mock::new(&expectations);
-
-        I2c::write(&mut i2c, 0xaa, &vec![1, 3]).await.unwrap();
     }
 
     #[test]
@@ -519,18 +416,6 @@ mod test {
 
         let mut buff = vec![0; 2];
         i2c.write(0xaa, &mut buff).unwrap();
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "i2c::write unexpected mode")]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn transaction_type_mismatch_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [Transaction::read(0xaa, vec![10, 12])];
-        let mut i2c = Mock::new(&expectations);
-
-        let mut buff = vec![0; 2];
-        I2c::write(&mut i2c, 0xaa, &mut buff).await.unwrap();
     }
 
     #[test]
@@ -544,21 +429,6 @@ mod test {
         i2c.write_read(0xaa, &v, &mut buff).unwrap();
     }
 
-    #[tokio::test]
-    #[should_panic(expected = "i2c::write_read address mismatch")]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn address_mismatch_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [Transaction::write_read(0xbb, vec![1, 2], vec![3, 4])];
-        let mut i2c = Mock::new(&expectations);
-
-        let v = vec![1, 2];
-        let mut buff = vec![0; 2];
-        I2c::write_read(&mut i2c, 0xaa, &v, &mut buff)
-            .await
-            .unwrap();
-    }
-
     #[test]
     #[should_panic(expected = "i2c::write unexpected mode")]
     fn test_i2c_mock_mode_err() {
@@ -566,19 +436,6 @@ mod test {
         let mut i2c = Mock::new(&expectations);
 
         i2c.write(0xaa, &vec![10, 12]).unwrap();
-
-        i2c.done();
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "i2c::write unexpected mode")]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn test_i2c_mock_mode_err_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [Transaction::read(0xaa, vec![10, 12])];
-        let mut i2c = Mock::new(&expectations);
-
-        I2c::write(&mut i2c, 0xaa, &vec![10, 12]).await.unwrap();
 
         i2c.done();
     }
@@ -593,22 +450,6 @@ mod test {
         let mut i2c = Mock::new(&expectations);
 
         i2c.write(0xaa, &vec![10, 12]).unwrap();
-
-        i2c.done();
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "Not all expectations consumed")]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn unconsumed_expectations_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [
-            Transaction::write(0xaa, vec![10, 12]),
-            Transaction::write(0xaa, vec![10, 12]),
-        ];
-        let mut i2c = Mock::new(&expectations);
-
-        I2c::write(&mut i2c, 0xaa, &vec![10, 12]).await.unwrap();
 
         i2c.done();
     }
@@ -644,39 +485,6 @@ mod test {
         }
     }
 
-    #[tokio::test]
-    #[cfg(feature = "embedded-hal-async")]
-    async fn clone_linked_to_original_async() {
-        use embedded_hal_async::i2c::I2c;
-        let expectations = [
-            Transaction::read(0xaa, vec![1, 2]),
-            Transaction::write(0xbb, vec![3, 4]),
-        ];
-        let mut i2c = Mock::new(&expectations);
-
-        // Clone mock. The clone should be linked to the same data as the original.
-        let mut i2c_clone = i2c.clone();
-
-        // Read on the original mock
-        let mut buff = vec![0; 2];
-        I2c::read(&mut i2c, 0xaa, &mut buff).await.unwrap();
-        assert_eq!(vec![1, 2], buff);
-
-        // Write on the clone
-        I2c::write(&mut i2c_clone, 0xbb, &[3, 4]).await.unwrap();
-
-        // Randomly call `.done()` on the original mock, or on the clone.
-        // Use "system time % 2" as poor man's `rand()`.
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap();
-        if now.as_millis() % 2 == 0 {
-            i2c.done();
-        } else {
-            i2c_clone.done();
-        }
-    }
-
     mod with_error {
         use super::*;
 
@@ -691,19 +499,6 @@ mod test {
             i2c.done();
         }
 
-        #[tokio::test]
-        #[cfg(feature = "embedded-hal-async")]
-        async fn write_async() {
-            use embedded_hal_async::i2c::I2c;
-            let expected_err = ErrorKind::Other;
-            let mut i2c = Mock::new(&[
-                Transaction::write(0xaa, vec![10, 12]).with_error(expected_err.clone())
-            ]);
-            let err = I2c::write(&mut i2c, 0xaa, &vec![10, 12]).await.unwrap_err();
-            assert_eq!(err, expected_err);
-            i2c.done();
-        }
-
         /// The transaction mode should still be validated.
         #[test]
         #[should_panic(expected = "i2c::read unexpected mode")]
@@ -714,18 +509,6 @@ mod test {
             let _ = i2c.read(0xaa, &mut buf);
         }
 
-        /// The transaction mode should still be validated.
-        #[tokio::test]
-        #[should_panic(expected = "i2c::read unexpected mode")]
-        #[cfg(feature = "embedded-hal-async")]
-        async fn write_wrong_mode_async() {
-            use embedded_hal_async::i2c::I2c;
-            let mut i2c =
-                Mock::new(&[Transaction::write(0xaa, vec![10, 12]).with_error(ErrorKind::Other)]);
-            let mut buf = vec![0; 2];
-            let _ = I2c::read(&mut i2c, 0xaa, &mut buf).await;
-        }
-
         /// The transaction bytes should still be validated.
         #[test]
         #[should_panic(expected = "i2c::write data does not match expectation")]
@@ -733,17 +516,6 @@ mod test {
             let mut i2c =
                 Mock::new(&[Transaction::write(0xaa, vec![10, 12]).with_error(ErrorKind::Other)]);
             let _ = i2c.write(0xaa, &vec![10, 13]);
-        }
-
-        /// The transaction bytes should still be validated.
-        #[tokio::test]
-        #[should_panic(expected = "i2c::write data does not match expectation")]
-        #[cfg(feature = "embedded-hal-async")]
-        async fn write_wrong_data_async() {
-            use embedded_hal_async::i2c::I2c;
-            let mut i2c =
-                Mock::new(&[Transaction::write(0xaa, vec![10, 12]).with_error(ErrorKind::Other)]);
-            let _ = I2c::write(&mut i2c, 0xaa, &vec![10, 13]).await;
         }
 
         #[test]
@@ -759,21 +531,6 @@ mod test {
             i2c.done();
         }
 
-        #[tokio::test]
-        #[cfg(feature = "embedded-hal-async")]
-        async fn read_async() {
-            use embedded_hal_async::i2c::I2c;
-            let expected_err = ErrorKind::Other;
-            let mut i2c =
-                Mock::new(
-                    &[Transaction::read(0xaa, vec![10, 12]).with_error(expected_err.clone())],
-                );
-            let mut buf = vec![0; 2];
-            let err = I2c::read(&mut i2c, 0xaa, &mut buf).await.unwrap_err();
-            assert_eq!(err, expected_err);
-            i2c.done();
-        }
-
         /// The transaction mode should still be validated.
         #[test]
         #[should_panic(expected = "i2c::write unexpected mode")]
@@ -781,17 +538,6 @@ mod test {
             let mut i2c =
                 Mock::new(&[Transaction::read(0xaa, vec![10, 12]).with_error(ErrorKind::Other)]);
             let _ = i2c.write(0xaa, &vec![10, 12]);
-        }
-
-        /// The transaction mode should still be validated.
-        #[tokio::test]
-        #[should_panic(expected = "i2c::write unexpected mode")]
-        #[cfg(feature = "embedded-hal-async")]
-        async fn read_wrong_mode_async() {
-            use embedded_hal_async::i2c::I2c;
-            let mut i2c =
-                Mock::new(&[Transaction::read(0xaa, vec![10, 12]).with_error(ErrorKind::Other)]);
-            let _ = I2c::write(&mut i2c, 0xaa, &vec![10, 12]).await;
         }
 
         #[test]
@@ -805,21 +551,6 @@ mod test {
             i2c.done();
         }
 
-        #[tokio::test]
-        #[cfg(feature = "embedded-hal-async")]
-        async fn write_read_async() {
-            use embedded_hal_async::i2c::I2c;
-            let expected_err = ErrorKind::Other;
-            let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
-                .with_error(expected_err.clone())]);
-            let mut buf = vec![0; 2];
-            let err = I2c::write_read(&mut i2c, 0xaa, &[10, 12], &mut buf)
-                .await
-                .unwrap_err();
-            assert_eq!(err, expected_err);
-            i2c.done();
-        }
-
         /// The transaction mode should still be validated.
         #[test]
         #[should_panic(expected = "i2c::write unexpected mode")]
@@ -827,17 +558,6 @@ mod test {
             let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
                 .with_error(ErrorKind::Other)]);
             let _ = i2c.write(0xaa, &vec![10, 12]);
-        }
-
-        /// The transaction mode should still be validated.
-        #[tokio::test]
-        #[should_panic(expected = "i2c::write unexpected mode")]
-        #[cfg(feature = "embedded-hal-async")]
-        async fn write_read_wrong_mode_async() {
-            use embedded_hal_async::i2c::I2c;
-            let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
-                .with_error(ErrorKind::Other)]);
-            let _ = I2c::write(&mut i2c, 0xaa, &vec![10, 12]).await;
         }
 
         /// The transaction bytes should still be validated.
@@ -849,17 +569,43 @@ mod test {
             let mut buf = vec![0; 2];
             let _ = i2c.write_read(0xaa, &vec![10, 13], &mut buf);
         }
+    }
 
-        /// The transaction bytes should still be validated.
-        #[tokio::test]
-        #[should_panic(expected = "i2c::write_read write data does not match expectation")]
-        #[cfg(feature = "embedded-hal-async")]
-        async fn write_read_wrong_data_async() {
-            use embedded_hal_async::i2c::I2c;
-            let mut i2c = Mock::new(&[Transaction::write_read(0xaa, vec![10, 12], vec![13, 14])
-                .with_error(ErrorKind::Other)]);
-            let mut buf = vec![0; 2];
-            let _ = I2c::write_read(&mut i2c, 0xaa, &vec![10, 13], &mut buf).await;
-        }
+    /// Test that the async trait impls call the synchronous variants under the hood.
+    #[tokio::test]
+    #[cfg(feature = "embedded-hal-async")]
+    async fn async_impls() {
+        use embedded_hal_async::i2c::I2c;
+        let expectations = [
+            Transaction::read(0xaa, vec![1, 2]),
+            Transaction::write(0xaa, vec![10, 12]),
+            Transaction::write_read(0xaa, vec![3, 4], vec![5, 6]),
+            Transaction::transaction_start(0xbb),
+            Transaction::write(0xbb, vec![7, 8]),
+            Transaction::transaction_end(0xbb),
+        ];
+        let mut i2c = Mock::new(&expectations);
+
+        // Test read
+        let mut buf = vec![0; 2];
+        I2c::read(&mut i2c, 0xaa, &mut buf).await.unwrap();
+        assert_eq!(vec![1, 2], buf);
+
+        // Test write
+        I2c::write(&mut i2c, 0xaa, &vec![10, 12]).await.unwrap();
+
+        // Test write_read
+        let mut buf = vec![0; 2];
+        I2c::write_read(&mut i2c, 0xaa, &vec![3, 4], &mut buf)
+            .await
+            .unwrap();
+        assert_eq!(vec![5, 6], buf);
+
+        // Test transaction
+        I2c::transaction(&mut i2c, 0xbb, &mut [i2c::Operation::Write(&vec![7, 8])])
+            .await
+            .unwrap();
+
+        i2c.done();
     }
 }

--- a/src/eh1/i2c.rs
+++ b/src/eh1/i2c.rs
@@ -26,14 +26,6 @@
 //! i2c.done();
 //! ```
 //!
-//! ## Transactions
-//!
-//! There are currently three transaction types:
-//!
-//! - `Read`: This expects an I²C `read` command and will return the wrapped bytes.
-//! - `Write`: This expects an I²C `write` command with the wrapped bytes.
-//!   `expected` bytes are written and the `response` bytes are returned.
-//!
 //! ## Testing Error Handling
 //!
 //! If you want to test error handling of your code, you can attach an error to

--- a/src/eh1/i2c.rs
+++ b/src/eh1/i2c.rs
@@ -336,9 +336,9 @@ mod test {
         let expectations = [Transaction::read(0xaa, vec![1, 2])];
         let mut i2c = Mock::new(&expectations);
 
-        let mut buff = vec![0; 2];
-        i2c.read(0xaa, &mut buff).unwrap();
-        assert_eq!(vec![1, 2], buff);
+        let mut buf = vec![0; 2];
+        i2c.read(0xaa, &mut buf).unwrap();
+        assert_eq!(vec![1, 2], buf);
 
         i2c.done();
     }
@@ -349,9 +349,9 @@ mod test {
         let mut i2c = Mock::new(&expectations);
 
         let v = vec![1, 2];
-        let mut buff = vec![0; 2];
-        i2c.write_read(0xaa, &v, &mut buff).unwrap();
-        assert_eq!(vec![3, 4], buff);
+        let mut buf = vec![0; 2];
+        i2c.write_read(0xaa, &v, &mut buf).unwrap();
+        assert_eq!(vec![3, 4], buf);
 
         i2c.done();
     }
@@ -414,8 +414,8 @@ mod test {
         let expectations = [Transaction::read(0xaa, vec![10, 12])];
         let mut i2c = Mock::new(&expectations);
 
-        let mut buff = vec![0; 2];
-        i2c.write(0xaa, &mut buff).unwrap();
+        let mut buf = vec![0; 2];
+        i2c.write(0xaa, &mut buf).unwrap();
     }
 
     #[test]
@@ -425,8 +425,8 @@ mod test {
         let mut i2c = Mock::new(&expectations);
 
         let v = vec![1, 2];
-        let mut buff = vec![0; 2];
-        i2c.write_read(0xaa, &v, &mut buff).unwrap();
+        let mut buf = vec![0; 2];
+        i2c.write_read(0xaa, &v, &mut buf).unwrap();
     }
 
     #[test]
@@ -466,9 +466,9 @@ mod test {
         let mut i2c_clone = i2c.clone();
 
         // Read on the original mock
-        let mut buff = vec![0; 2];
-        i2c.read(0xaa, &mut buff).unwrap();
-        assert_eq!(vec![1, 2], buff);
+        let mut buf = vec![0; 2];
+        i2c.read(0xaa, &mut buf).unwrap();
+        assert_eq!(vec![1, 2], buf);
 
         // Write on the clone
         i2c_clone.write(0xbb, &[3, 4]).unwrap();

--- a/src/eh1/spi.rs
+++ b/src/eh1/spi.rs
@@ -530,10 +530,10 @@ mod test {
 
         let mut spi = Mock::new(&[Transaction::read(10)]);
 
-        let mut buff = vec![0u8; 1];
-        SpiBus::read(&mut spi, &mut buff).unwrap();
+        let mut buf = vec![0u8; 1];
+        SpiBus::read(&mut spi, &mut buf).unwrap();
 
-        assert_eq!(buff, [10]);
+        assert_eq!(buf, [10]);
 
         spi.done();
     }
@@ -544,10 +544,10 @@ mod test {
 
         let mut spi = Mock::new(&[Transaction::read(0xFFFF_u16)]);
 
-        let mut buff = vec![0u16; 1];
-        SpiBus::read(&mut spi, &mut buff).unwrap();
+        let mut buf = vec![0u16; 1];
+        SpiBus::read(&mut spi, &mut buf).unwrap();
 
-        assert_eq!(buff, [0xFFFF_u16]);
+        assert_eq!(buf, [0xFFFF_u16]);
 
         spi.done();
     }


### PR DESCRIPTION
Some cleanup commits. The async simplification was discussed here: https://github.com/dbrgn/embedded-hal-mock/pull/119#pullrequestreview-2079775113 @asasine do you want to take a look at this PR?

Note: The delay async tests were not removed, since in the delay module, the async impl doesn't just call through to the sync impl.