### PR TITLE
Fix checking address on I2C transaction start/end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Check address in I2C transaction start/end operations. (#121)
+
 ### Changed
 
 

--- a/src/eh1/i2c.rs
+++ b/src/eh1/i2c.rs
@@ -264,6 +264,10 @@ impl I2c for Mock {
             Mode::TransactionStart,
             "i2c::transaction_start unexpected mode"
         );
+        assert_eq!(
+            w.expected_addr, address,
+            "i2c::transaction_start address mismatch"
+        );
 
         for op in operations {
             match op {
@@ -281,6 +285,10 @@ impl I2c for Mock {
             w.expected_mode,
             Mode::TransactionEnd,
             "i2c::transaction_end unexpected mode"
+        );
+        assert_eq!(
+            w.expected_addr, address,
+            "i2c::transaction_end address mismatch"
         );
 
         Ok(())


### PR DESCRIPTION
I have noticed that the addresses supplied in the transaction start/end are not checked. Hence this PR.
Although I am wondering now if the transaction start/end should have an address parameter at all. Maybe we should remove it altogether.