### PR TITLE
remove `eh0` feature from default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Drop fixed MSRV policy (#124)
+- **Breaking**: the `eh0` feature is no longer part of the default features.
+  it still exists as an optional feature and has to be explicitly added when needed.
 
 
 ## 0.11.1 - 2024-06-02

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ eh1 = ["dep:eh1", "dep:embedded-hal-nb"]
 embedded-time = ["dep:embedded-time", "dep:void"]
 embedded-hal-async = ["dep:embedded-hal-async"]
 
-default = ["eh0", "eh1", "embedded-time"]
+default = ["eh1", "embedded-time"]
 
 [dependencies]
 eh0 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"], optional = true }


### PR DESCRIPTION
`embedded-hal` v1.0 came out in january 2024, going forward new code should use this. accordingly, `eh0` support should no longer be part of the default features to reduce the amount of dependencies being pulled in.

existing code will likely still use it, thus consumers will have to explicitly enable the feature when upgrading.

CC @tommy-gilligan (you suggested the same [as part of your larger draft](https://github.com/dbrgn/embedded-hal-mock/pull/115/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R29)) & @eldruin (i noticed it due to your comment here: https://github.com/rust-embedded-community/tb6612fng-rs/pull/51#pullrequestreview-2154759310)