### PR TITLE
Added WaitForEdgeForever and WaitForStateForever transactions, which return a Pending future to the callee.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ eh0 = ["dep:eh0", "dep:nb"]
 eh1 = ["dep:eh1", "dep:embedded-hal-nb"]
 
 embedded-time = ["dep:embedded-time", "dep:void"]
-embedded-hal-async = ["dep:embedded-hal-async"]
+embedded-hal-async = ["dep:embedded-hal-async","dep:futures"]
 
 default = ["eh1", "embedded-time"]
 
@@ -33,12 +33,13 @@ eh0 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"], op
 eh1 = { package = "embedded-hal", version = "1.0", optional = true }
 embedded-hal-nb = { version = "1.0", optional = true }
 embedded-hal-async = { version = "1.0", optional = true }
+futures = { version = "0.3.31", default-features = false, optional = true }
 embedded-time = { version = "0.12", optional = true }
 nb = { version = "1.1", optional = true }
 void = { version = "^1.0", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.21.1", features = ["rt", "macros"] }
+tokio = { version = "1.21.1", features = ["rt", "macros", "time"] }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I have some code I'd like to mock for a quadrature encoder, which uses `select(pin_clk,pin_data)`. 
In order to properly test it, I need to be able to mock different paths in the select statement.

As it stands currently, the current async transactions always return `Ok()` when called - this means my `select()` paths are always taking the first branch.

The solution I propose here is to add a modified `WaitForEdge/WaitForState` enum called `WaitFor{State,Edge}Forever`, which returns a `Pending` future. This simulates a pin that never changes, while still allowing a mock transaction for the actual `wait_for_edge` call.

I have added tests for this, which poll the returned future for 10 milliseconds before timing-out (successful result).